### PR TITLE
Create static HTML CV site

### DIFF
--- a/generate_site.py
+++ b/generate_site.py
@@ -1,0 +1,30 @@
+import markdown
+from pathlib import Path
+
+readme_text = Path('README.md').read_text(encoding='utf-8')
+html_body = markdown.markdown(readme_text)
+
+html_template = f"""
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <title>Alexey Belyakov - CV</title>
+    <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<header>
+    <h1>Alexey Belyakov</h1>
+</header>
+<div class='content'>
+{html_body}
+</div>
+<footer>
+    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
+</footer>
+</body>
+</html>
+"""
+
+Path('index.html').write_text(html_template, encoding='utf-8')

--- a/index.html
+++ b/index.html
@@ -1,0 +1,173 @@
+
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <title>Alexey Belyakov - CV</title>
+    <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<header>
+    <h1>Alexey Belyakov</h1>
+</header>
+<div class='content'>
+<h1>Alexey Leonidovich Belyakov</h1>
+<p><em><a href="./README_ru.md">Link to russian version</a></em> \
+<em><a href="./latex/en/Belyakov_en.pdf">Link to PDF</a></em> \
+<em><a href="./latex/ru/Belyakov_ru.pdf">Link to russian PDF</a></em></p>
+<ul>
+<li><strong>Phone:</strong> +7 (911) 261-70-72</li>
+<li><strong>Telegram:</strong> <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
+<li><strong>Email:</strong> qqrm@vivaldi.net</li>
+<li><strong>GitHub:</strong> <a href="https://github.com/qqrm">github.com/qqrm</a></li>
+</ul>
+<p>Languages:
+- Russian (Native)
+- English (B2 — Advanced)</p>
+<p>Work Schedule: Remote work, full-time</p>
+<h1>Objective:</h1>
+<p>A highly skilled Rust Team Lead with nearly 10 years of software development and system architecture experience. Committed to driving innovation in robust, high-performance systems and empowering teams to deliver impactful solutions. Seeking to leverage deep technical expertise, leadership skills, and microservices best practices to build high-performing development teams, streamline processes, and achieve business objectives in cutting-edge projects.</p>
+<h2>Work Experience</h2>
+<h3>Rust Team Lead @ Inline Group | <a href="https://www.inlinegroup.ru">www.inlinegroup.ru</a></h3>
+<p><em>March 2024 – Present  (1 year)</em></p>
+<ul>
+<li>Led a 12-person backend team (part of a 40+ overall project staff) in an import substitution initiative to migrate business processes from SAP to a custom Rust-based microservices ecosystem.
+Architected and maintained microservices using Actix Web, RabbitMQ, PostgreSQL, and other technologies, ensuring high throughput and reliability.</li>
+<li>Introduced and enforced Agile practices (Scrum, sprints, daily standups, retrospectives), increasing development velocity by ~20% and reducing rework.</li>
+<li>Defined infrastructure requirements (CI/CD pipelines, test environments) and coordinated with DevOps to streamline deployments in a corporate on-premise environment.</li>
+<li>Spearheaded the hiring and onboarding process: expanded the backend team from 5 to 12 developers, reducing average onboarding time by ~30%.</li>
+<li>Implemented a custom Cargo registry to meet stringent security requirements, integrating static code analysis (Clippy, cargo-audit, SonarQube, etc.) into the pipeline.</li>
+<li>Oversaw architectural decisions, code reviews, and performance optimizations; decreased bug backlog by ~30% after instituting more rigorous QA and review practices.</li>
+<li>Collaborated with business analysts and key stakeholders to transform high-level SAP-based requirements into microservice-oriented solutions, cutting turnaround time for new features by ~25%.</li>
+</ul>
+<h4>Key Achievements</h4>
+<ul>
+<li>Improved sprint productivity by ~15% through implementing async and personal sprint planning.</li>
+<li>Improved sprint predictability by ~25% through more accurate estimation and better backlog refinement.</li>
+<li>Established transparent reporting and roadmap tracking for stakeholders, enhancing cross-team communication and aligning business priorities with technical execution.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust, Actix Web, RabbitMQ, PostgreSQL, Docker, GitLab CI/CD, Odoo, Clippy, cargo-audit, SonarQube</p>
+<h3>Lead Rust Developer @ YADRO | <a href="https://www.yadro.com">www.yadro.com</a></h3>
+<p><em>March 2023 — March 2024 (1 year)</em></p>
+<ul>
+<li>Enhanced the architecture of a hardware-software complex for deduplication-based backup solutions.</li>
+<li>Conducted research on optimizing RoksDB and enhancing NVMe disk performance.</li>
+<li>Implemented data structures for efficient storage of hashes and hash-hashes.</li>
+<li>Resolved bugs and improved compression and deduplication modules.</li>
+<li>Conducted code reviews and delivered internal lectures on Rust to transition ex-C++ developers to idiomatic Rust, decreasing onboarding time by 30%.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust, Tokio, Protocol Buffers, Serde, RoksDB, Git.</p>
+<h3>Senior Rust/Python Developer (Part-Time) @ Ultima-bi</h3>
+<p><em>Nov 2022 - Mar 2023 (5 months)</em></p>
+<ul>
+<li>Developed Python wrappers and a caching system for a data science tool based on Polars, ensuring seamless Rust ↔ Python integration.</li>
+<li>Leveraged PyO3 to accelerate critical code paths, achieving ~25% faster data processing.</li>
+<li>Designed automated tests to ensure reliability and maintainability of the hybrid Python-Rust solution.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust (Programming Language), Python3, PyO3, Git</p>
+<h3>Rust Team Lead @ Solcery</h3>
+<p><em>March 2022 — March 2023 (1 year)</em></p>
+<ul>
+<li>Led a team of 4 Rust developers to build a blockchain-based database using Solana smart contracts, focusing on DAO and card game frameworks.</li>
+<li>Architected and implemented low-level data storage structures, versioning, and table migrations, reducing code complexity by ~20%.</li>
+<li>Formulated requirements from user stories, bridging technical and business aspects for clear deliverables.
+Coordinated sprints, assigned tasks, tracked timelines, and ensured on-time delivery of features.</li>
+<li>Conducted code reviews, reducing production bugs by ~30% through early detection of issues.</li>
+</ul>
+<h4>Key Achievements</h4>
+<ul>
+<li>Streamlined the Rust development workflow, cutting average code review time by 40%.</li>
+<li>Established best practices for versioning and migrations, enabling seamless DAO-based solutions for card game frameworks.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust, Solana Test Validator, Git, GitHub.</p>
+<h3>Senior Rust Developer @ Kaspersky Lab | <a href="https://www.kaspersky.ru">www.kaspersky.ru</a></h3>
+<p><em>May 2021 — March 2022 (11 months)</em></p>
+<ul>
+<li>Maintained and enhanced a blockchain-based voting service built on Exonum, adding weight-based voting functionalities.</li>
+<li>Expanded integration and unit test coverage to ~75%, strengthening overall code quality.
+Facilitated the migration to the Microsoft ecosystem, refining CI/CD pipelines for more efficient deployments.</li>
+</ul>
+<h4>Key Achievements</h4>
+<ul>
+<li>Reduced post-deployment issues by ~25% through improved test coverage and robust CI processes.</li>
+<li>Refactored the codebase for better maintainability, simplifying future feature additions.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust, Exonum, Protocol Buffers, Serde, Git.</p>
+<h3>Rust Developer @ Kryptonite | <a href="https://www.kryptonite.ru">www.kryptonite.ru</a></h3>
+<p><em>May 2020 — May 2021 (1 year 1 month)</em></p>
+<ul>
+<li>Migrated a legacy Scala-based voice call processing system to Rust, improving performance and reducing memory usage.</li>
+<li>Implemented voice recording normalization and embeddings-based analysis for high-accuracy indexing.</li>
+<li>Developed synchronization modules for multi-track dialogues, increasing data integrity.</li>
+<li>Created comprehensive unit test suites to validate new features and maintain stability.</li>
+</ul>
+<h4>Key Achievements</h4>
+<ul>
+<li>Achieved ~20% performance boost compared to the Scala version, enabling faster call analysis.</li>
+<li>Reduced memory footprint by ~25% through optimized concurrency patterns in Rust.</li>
+</ul>
+<p><strong>Technologies</strong>: Rust, PostgreSQL, nalgebra, Serde, Protocol Buffers, Tokio, Git.</p>
+<h3>Senior C++/Go Developer @ B2Broker | <a href="https://www.b2broker.com">www.b2broker.com</a></h3>
+<p><em>November 2018 — March 2020 (1 year 6 months)</em></p>
+<ul>
+<li>Developed financial software using MT4/MT5 APIs, including trade copiers in C++ and Go.</li>
+<li>Built a Multi Account Manager for flexible fund delegation and reward calculation, boosting operational efficiency by ~15%.</li>
+<li>Designed microservices in C++ and Go for data normalization and delivery from MT4/MT5 to widgets, ensuring real-time data updates.</li>
+<li>Implemented data collectors for statistical analysis, providing better insights for brokers.</li>
+</ul>
+<p><strong>Technologies</strong>: MSVC, CMake, Protocol Buffers, gRPC, NATS, YAML, PostgreSQL, Vcpkg, Git.</p>
+<h3>Middle-&gt;Senior C++ Developer @ ASCON | <a href="https://www.ascon.ru">www.ascon.ru</a></h3>
+<p><em>May 2016 — November 2018 (2 years 7 months)</em></p>
+<ul>
+<li>Developed libraries for architectural design (KOMPAS), adding a “Change View Plane” feature to enhance 3D modeling capabilities.</li>
+<li>Implemented an automated testing framework (C++/Python), reducing manual QA overhead by ~30%.</li>
+<li>Participated in a major codebase refactoring, transitioning to C++17.</li>
+<li>Introduced Git, Slack, and integration tests, streamlining collaboration processes.</li>
+</ul>
+<p><strong>Technologies</strong>: MSVC, C++, Boost, kompas-api, python, git, svn, CMake.</p>
+<h3>Middle С++ Developer @ Con Certeza</h3>
+<p><em>March 2015 — April 2016 (1 year 2 months)</em></p>
+<ul>
+<li>Developed a sniffer and parser for signaling traffic (comprising the entire SS7 protocol stack) as part of the SORM system for MTS.</li>
+<li>Authored parsers for protocols, including:<ul>
+<li>INAP</li>
+<li>RANAP</li>
+<li>MAP</li>
+<li>TCAP</li>
+<li>CAP</li>
+<li>MTP3</li>
+<li>MTP2</li>
+<li>SCCP</li>
+<li>SIP</li>
+</ul>
+</li>
+<li>Designed and implemented modules to gather information from traffic based on RFC protocols for:<ul>
+<li>SMS</li>
+<li>Subscriber movements</li>
+<li>Telephone calls</li>
+</ul>
+</li>
+<li>Created integration tests for the implemented functionality using Python.</li>
+</ul>
+<p><strong>Technologies</strong>: Myri10GE API, libpcap, PF_RING, C++11, Boost, Python.</p>
+<h3>Middle C++/JS Developer @ LiveTex | <a href="https://www.livetex.ru">www.livetex.ru</a></h3>
+<p><em>July 2014 — March 2015 (7 months)</em></p>
+<ul>
+<li>Created wrapper modules for PostgreSQL and ZeroMQ for Node.js.</li>
+</ul>
+<p><strong>Technologies</strong>: gcc, C++, node.js, JS.</p>
+<h3>Junior C++ Developer @ Tools for Brokers | <a href="https://www.t4b.com">t4b.com</a></h3>
+<p><em>November 2013 — July 2014 (9 months)</em></p>
+<ul>
+<li>Developed for the MetaTrader 4 and 5 platforms.</li>
+<li>Enhanced and debugged a plug-in for mutual fund investments (UMAM).</li>
+<li>Built a web application for MT4 server management.</li>
+</ul>
+<p><strong>Technologies</strong>: C++, Boost, C#, JS.</p>
+</div>
+<footer>
+    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
+</footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2em;
+    line-height: 1.6;
+}
+header {
+    text-align: center;
+    margin-bottom: 2em;
+}
+.content h1, .content h2, .content h3 {
+    margin-top: 1.2em;
+}
+a {
+    color: #0645ad;
+}


### PR DESCRIPTION
## Summary
- add Python script that converts README.md into a minimal HTML page
- generate `index.html` with links to existing PDF files
- add basic styling via `style.css`

## Testing
- `python3 generate_site.py`

------
https://chatgpt.com/codex/tasks/task_e_687f573139048332b797d657c475038e