### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
@@ -28,6 +30,7 @@ jobs:
       - name: Generate site
         run: cargo run --release --manifest-path sitegen/Cargo.toml
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -27,6 +27,12 @@ jobs:
         run: cargo build --release --manifest-path sitegen/Cargo.toml
       - name: Generate site
         run: cargo run --release --manifest-path sitegen/Cargo.toml
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: .
       - name: Upload generated index.html
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update site generator workflow to publish generated files to `gh-pages`

## Testing
- `cargo run --release --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687f5aecc3388332b16263d44e406025