### PR TITLE
Fix duplicate name on site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,9 +6,6 @@
     <link rel='stylesheet' href='style.css'>
 </head>
 <body>
-<header>
-    <h1>Alexey Belyakov</h1>
-</header>
 <div class='content'>
 <h1>Alexey Leonidovich Belyakov</h1>
 <p><em><a href="README_ru.md">Link to russian version</a></em> \

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     html_body = html_body.replace("./README_ru.md", "README_ru.md");
 
     let html_template = format!(
-        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n</header>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
         html_body
     );
 


### PR DESCRIPTION
## Summary
- remove redundant header from site generator
- regenerate `docs/index.html`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo run --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687fbc3dec6083328a43a6454d1e3e76