### PR TITLE
Обновление CI для генерации сайта

### DIFF
--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -6,6 +6,7 @@ on:
       - 'README.md'
       - 'README_ru.md'
       - 'docs/style.css'
+      - 'latex/**'
       - 'sitegen/**'
       - '.github/workflows/sitegen.yml'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - 'README.md'
       - 'README_ru.md'
       - 'docs/style.css'
+      - 'latex/**'
       - 'sitegen/**'
       - '.github/workflows/sitegen.yml'
 
@@ -33,17 +35,23 @@ jobs:
         run: cargo build --release --manifest-path sitegen/Cargo.toml
       - name: Generate site
         run: cargo run --release --manifest-path sitegen/Cargo.toml
+      - name: Install LaTeX packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra \
+            texlive-fonts-recommended texlive-lang-cyrillic latexmk
+      - name: Build English PDF
+        working-directory: latex/en
+        run: latexmk -pdf -quiet Belyakov_en.tex
+      - name: Build Russian PDF
+        working-directory: latex/ru
+        run: latexmk -pdf -quiet Belyakov_ru.tex
       - name: Copy PDFs and README_ru
         run: |
           mkdir -p docs/latex/en docs/latex/ru
           cp latex/en/Belyakov_en.pdf docs/latex/en/
           cp latex/ru/Belyakov_ru.pdf docs/latex/ru/
           cp README_ru.md docs/
-      - name: Upload generated index.html
-        uses: actions/upload-artifact@v4
-        with:
-          name: index-html
-          path: docs/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /target/
 sitegen/target/
 /index.html
+docs/index.html
+latex/**/*.pdf


### PR DESCRIPTION
## Изменения
- добавлены `docs/index.html` и `latex/**/*.pdf` в `.gitignore`
- обновлён workflow `sitegen.yml`: теперь он собирает HTML и PDF из исходников и разворачивает их на GitHub Pages

## Тестирование
- `cargo test --manifest-path sitegen/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_687fbeb660788332a70abf229eabede9