### PR TITLE
Fix sitegen workflow on PRs

### DIFF
--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -51,8 +51,10 @@ jobs:
           cp README_ru.md docs/
 
       - name: Setup Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
       - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './docs'

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !docs_dir.exists() {
         fs::create_dir_all(docs_dir)?;
     }
-    fs::write(docs_dir.join("index.html"), html_template_en)?;
+    fs::write(docs_dir.join("index.html"), html_template)?;
 
     let ru_dir = docs_dir.join("ru");
     if !ru_dir.exists() {


### PR DESCRIPTION
## Summary
- avoid running GitHub Pages deployment steps on non-main branches
- fix typo in sitegen `main.rs`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687fbd556d588332bb842b31137c7533