### PR TITLE
Fix duplicate name on Russian page

### DIFF
--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -6,9 +6,6 @@
     <link rel='stylesheet' href='../style.css'>
 </head>
 <body>
-<header>
-    <h1>Алексей Беляков</h1>
-</header>
 <div class='content'>
 <h1>Алексей Леонидович Беляков</h1>
 <ul>

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     html_body_ru = html_body_ru.replace("./latex/", "../latex/");
 
     let html_template_ru = format!(
-        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n</header>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
         html_body_ru
     );
 
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !docs_dir.exists() {
         fs::create_dir_all(docs_dir)?;
     }
-    fs::write(docs_dir.join("index.html"), html_template_en)?;
+    fs::write(docs_dir.join("index.html"), html_template)?;
 
     let ru_dir = docs_dir.join("ru");
     if !ru_dir.exists() {


### PR DESCRIPTION
## Summary
- remove extra header from Russian site template
- fix variable name so `sitegen` compiles
- regenerate Russian HTML

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo run --manifest-path sitegen/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_687fc9811f3c8332a2bc99de41178203