### PR TITLE
Add LinkedIn avatar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div class='content'>
+<img class='avatar' src='https://media.licdn.com/dms/image/v2/D4E03AQFCGQAKN1uYvw/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1720862027144?e=2147483647&v=beta&t=WVbFPqJfgl6EtHuQOyOjyggtRPVVoFvp3w2S2hNW0v4' alt='Avatar'>
 <h1>Alexey Leonidovich Belyakov</h1>
 <p><em><a href="ru/">Link to russian version</a></em> \
 <em><a href="latex/en/Belyakov_en.pdf">Link to PDF</a></em> \

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -10,6 +10,7 @@
     <h1>Алексей Беляков</h1>
 </header>
 <div class='content'>
+<img class='avatar' src='https://media.licdn.com/dms/image/v2/D4E03AQFCGQAKN1uYvw/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1720862027144?e=2147483647&v=beta&t=WVbFPqJfgl6EtHuQOyOjyggtRPVVoFvp3w2S2hNW0v4' alt='Avatar'>
 <h1>Алексей Леонидович Беляков</h1>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>

--- a/docs/style.css
+++ b/docs/style.css
@@ -15,3 +15,12 @@ header {
 a {
     color: #0645ad;
 }
+
+.avatar {
+    display: block;
+    margin: 0 auto 1em;
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    object-fit: cover;
+}

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const AVATAR_URL: &str = "https://media.licdn.com/dms/image/v2/D4E03AQFCGQAKN1uYvw/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1720862027144?e=2147483647&v=beta&t=WVbFPqJfgl6EtHuQOyOjyggtRPVVoFvp3w2S2hNW0v4";
     // Generate English version
     let markdown_input = fs::read_to_string("README.md")?;
     let parser = Parser::new_ext(&markdown_input, Options::all());
@@ -12,7 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     html_body = html_body.replace("./README_ru.md", "ru/");
 
     let html_template = format!(
-        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        AVATAR_URL,
         html_body
     );
 
@@ -24,7 +26,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     html_body_ru = html_body_ru.replace("./latex/", "../latex/");
 
     let html_template_ru = format!(
-        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n</header>\n<div class='content'>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        AVATAR_URL,
         html_body_ru
     );
 
@@ -32,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !docs_dir.exists() {
         fs::create_dir_all(docs_dir)?;
     }
-    fs::write(docs_dir.join("index.html"), html_template_en)?;
+    fs::write(docs_dir.join("index.html"), html_template)?;
 
     let ru_dir = docs_dir.join("ru");
     if !ru_dir.exists() {


### PR DESCRIPTION
## Summary
- add LinkedIn avatar URL constant and embed it into generated pages
- style avatar via CSS

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_687fcafeea248332b8ec554d4aed386a