### PR TITLE
Fix site build pipeline

### DIFF
--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -27,11 +27,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download sitegen binary
         run: |
-          curl -L -o sitegen \
+          curl -L -o sitegen_binary \
             "https://github.com/${{ github.repository }}/releases/latest/download/sitegen"
-          chmod +x sitegen
+          chmod +x sitegen_binary
       - name: Generate site
-        run: ./sitegen
+        run: ./sitegen_binary
       - name: Install LaTeX packages
         run: |
           sudo apt-get update

--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -31,7 +31,7 @@ jobs:
             "https://github.com/${{ github.repository }}/releases/latest/download/sitegen"
           chmod +x sitegen
       - name: Generate site
-        run: cargo run --release --manifest-path sitegen/Cargo.toml
+        run: ./sitegen
       - name: Install LaTeX packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- run site generator from downloaded binary in GitHub Actions

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687fcb49a74c83329a635c81ae97d9d9