### PR TITLE
fix duplicate name on site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,6 @@
 <body>
 <div class='content'>
 <img class='avatar' src='https://media.licdn.com/dms/image/v2/D4E03AQFCGQAKN1uYvw/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1720862027144?e=2147483647&v=beta&t=WVbFPqJfgl6EtHuQOyOjyggtRPVVoFvp3w2S2hNW0v4' alt='Avatar'>
-<h1>Alexey Leonidovich Belyakov</h1>
 <p><em><a href="ru/">Link to russian version</a></em> \
 <em><a href="latex/en/Belyakov_en.pdf">Link to PDF</a></em> \
 <em><a href="latex/ru/Belyakov_ru.pdf">Link to russian PDF</a></em></p>

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -6,9 +6,11 @@
     <link rel='stylesheet' href='../style.css'>
 </head>
 <body>
+<header>
+    <h1>Алексей Беляков</h1>
+</header>
 <div class='content'>
 <img class='avatar' src='https://media.licdn.com/dms/image/v2/D4E03AQFCGQAKN1uYvw/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1720862027144?e=2147483647&v=beta&t=WVbFPqJfgl6EtHuQOyOjyggtRPVVoFvp3w2S2hNW0v4' alt='Avatar'>
-<h1>Алексей Леонидович Беляков</h1>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -11,11 +11,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     push_html(&mut html_body, parser);
     html_body = html_body.replace("./latex/", "latex/");
     html_body = html_body.replace("./README_ru.md", "ru/");
+    if let Some(end) = html_body.find("</h1>") {
+        html_body = html_body[end + 5..].trim_start().to_string();
+    }
 
     let html_template = format!(
         "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        AVATAR_URL,
-        html_body
+        AVATAR_URL, html_body
     );
 
     // Generate Russian version
@@ -24,11 +26,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut html_body_ru = String::new();
     push_html(&mut html_body_ru, parser_ru);
     html_body_ru = html_body_ru.replace("./latex/", "../latex/");
+    if let Some(end) = html_body_ru.find("</h1>") {
+        html_body_ru = html_body_ru[end + 5..].trim_start().to_string();
+    }
 
     let html_template_ru = format!(
         "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        AVATAR_URL,
-        html_body_ru
+        AVATAR_URL, html_body_ru
     );
 
     let docs_dir = Path::new("docs");


### PR DESCRIPTION
## Summary
- remove top `<h1>` from generated HTML
- regenerate docs with the updated generator

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo run --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_687fe17e54348332897e2246d84a5977