### PR TITLE
Fix header absence on English CV page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,9 @@
     <link rel='stylesheet' href='style.css'>
 </head>
 <body>
+<header>
+    <h1>Alexey Belyakov</h1>
+</header>
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 <p><em><a href="ru/">Link to russian version</a></em> \

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let html_template = format!(
-        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n</footer>\n</body>\n</html>\n",
         AVATAR_SRC_EN, html_body
     );
 


### PR DESCRIPTION
## Summary
- show "Alexey Belyakov" header on the English version of the site

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo run --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68809aa44ec48332a90e9620a3a72bd8