### PR TITLE
Remove redundant Rust description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A highly skilled Rust Team Lead with nearly 10 years of software development and
 - Leveraged PyO3 to accelerate critical code paths, achieving ~25% faster data processing.
 - Designed automated tests to ensure reliability and maintainability of the hybrid Python-Rust solution.
 
-**Technologies**: Rust (Programming Language), Python3, PyO3, Git
+**Technologies**: Rust, Python3, PyO3, Git
 
 ### Rust Team Lead @ Solcery
 *March 2022 — March 2023 (1 year)*

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,7 @@
 <li>Leveraged PyO3 to accelerate critical code paths, achieving ~25% faster data processing.</li>
 <li>Designed automated tests to ensure reliability and maintainability of the hybrid Python-Rust solution.</li>
 </ul>
-<p><strong>Technologies</strong>: Rust (Programming Language), Python3, PyO3, Git</p>
+<p><strong>Technologies</strong>: Rust, Python3, PyO3, Git</p>
 <h3>Rust Team Lead @ Solcery</h3>
 <p><em>March 2022 — March 2023 (1 year)</em></p>
 <ul>


### PR DESCRIPTION
## Summary
- clean up extra wording about Rust in README

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6880d4259efc83329d215b45a3ca1c3b