### PR TITLE
Add setup-cv action and new TypePDF workflow

### DIFF
--- a/.github/actions/setup-cv/action.yml
+++ b/.github/actions/setup-cv/action.yml
@@ -1,0 +1,28 @@
+name: 'Setup LaTeX and Typst and build PDFs'
+description: 'Install dependencies and build both LaTeX and Typst PDFs.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install LaTeX packages
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y texlive-latex-recommended texlive-latex-extra \
+          texlive-fonts-recommended texlive-lang-cyrillic latexmk
+    - name: Install Typst
+      shell: bash
+      run: cargo install typst-cli --locked
+    - name: Build English PDF
+      shell: bash
+      working-directory: latex/en
+      run: latexmk -pdf -quiet Belyakov_en.tex
+    - name: Build Russian PDF
+      shell: bash
+      working-directory: latex/ru
+      run: latexmk -pdf -quiet Belyakov_ru.tex
+    - name: Build Typst English PDF
+      shell: bash
+      run: typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
+    - name: Build Typst Russian PDF
+      shell: bash
+      run: typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -17,22 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install LaTeX packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-lang-cyrillic latexmk
-      - name: Install Typst
-        run: cargo install typst-cli --locked
-      - name: Build English PDF
-        working-directory: latex/en
-        run: latexmk -pdf -quiet Belyakov_en.tex
-      - name: Build Russian PDF
-        working-directory: latex/ru
-        run: latexmk -pdf -quiet Belyakov_ru.tex
-      - name: Build Typst English PDF
-        run: typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
-      - name: Build Typst Russian PDF
-        run: typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
+      - uses: ./.github/actions/setup-cv
       - name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_typepdf.yml
+++ b/.github/workflows/build_typepdf.yml
@@ -1,0 +1,23 @@
+name: Build CV PDFs with TypePDF
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install TypePDF
+        run: cargo install typepdf --locked
+      - name: Build English PDF with TypePDF
+        run: typepdf typst/en/Belyakov_en.typ typst/en/Belyakov_en_typepdf.pdf
+      - name: Build Russian PDF with TypePDF
+        run: typepdf typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_typepdf.pdf
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v4
+        with:
+          name: typepdf-pdfs
+          path: |
+            typst/en/Belyakov_en_typepdf.pdf
+            typst/ru/Belyakov_ru_typepdf.pdf

--- a/.github/workflows/manual_build_pdf.yml
+++ b/.github/workflows/manual_build_pdf.yml
@@ -11,26 +11,11 @@ jobs:
       - name: Set build date
         id: date
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Install LaTeX packages
+      - name: Insert build date
         run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-lang-cyrillic latexmk
-      - name: Install Typst
-        run: cargo install typst-cli --locked
-      - name: Build English PDF
-        working-directory: latex/en
-        run: |
-          sed '/^\\author/a \\date{'"$DATE"'}' Belyakov_en.tex > build.tex
-          latexmk -pdf -quiet -jobname=Belyakov_en build.tex
-      - name: Build Russian PDF
-        working-directory: latex/ru
-        run: |
-          sed '/^\\author/a \\date{'"$DATE"'}' Belyakov_ru.tex > build.tex
-          latexmk -pdf -quiet -jobname=Belyakov_ru build.tex
-      - name: Build Typst English PDF
-        run: typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
-      - name: Build Typst Russian PDF
-        run: typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
+          sed -i '/^\\author/a \\date{'"$DATE"'}' latex/en/Belyakov_en.tex
+          sed -i '/^\\author/a \\date{'"$DATE"'}' latex/ru/Belyakov_ru.tex
+      - uses: ./.github/actions/setup-cv
       - name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sitegen.yml
+++ b/.github/workflows/sitegen.yml
@@ -40,23 +40,7 @@ jobs:
           chmod +x sitegen_binary
       - name: Generate site
         run: ./sitegen_binary
-      - name: Install LaTeX packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra \
-            texlive-fonts-recommended texlive-lang-cyrillic latexmk
-      - name: Install Typst
-        run: cargo install typst-cli --locked
-      - name: Build English PDF
-        working-directory: latex/en
-        run: latexmk -pdf -quiet Belyakov_en.tex
-      - name: Build Russian PDF
-        working-directory: latex/ru
-        run: latexmk -pdf -quiet Belyakov_ru.tex
-      - name: Build Typst English PDF
-        run: typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
-      - name: Build Typst Russian PDF
-        run: typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
+      - uses: ./.github/actions/setup-cv
       - name: Copy PDFs and README_ru
         run: |
           mkdir -p docs/latex/en docs/latex/ru

--- a/.github/workflows/sitegen_release.yml
+++ b/.github/workflows/sitegen_release.yml
@@ -32,6 +32,7 @@ jobs:
           override: true
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml
+      - uses: ./.github/actions/setup-cv
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- add a composite action to install LaTeX/Typst and compile PDFs
- integrate the action into build, manual build, sitegen and release workflows
- add workflow for building PDFs with TypePDF

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68810d0c03fc8332ba8ebb83893fa3cf