### PR TITLE
Add avatar to CV PDFs

### DIFF
--- a/latex/en/Belyakov_en.tex
+++ b/latex/en/Belyakov_en.tex
@@ -5,6 +5,8 @@
 \usepackage{geometry}
 \usepackage{hyperref}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{tikz}
 
 \geometry{a4paper, total={170mm,257mm}, left=20mm, top=20mm}
 
@@ -12,9 +14,19 @@
 \author{Alexey Leonidovich Belyakov}
 \date{\today}
 
+\newcommand{\avatar}{%
+    \begin{center}
+        \begin{tikzpicture}
+            \clip (0,0) circle (1.5cm);
+            \node at (0,0) {\includegraphics[width=3cm,height=3cm]{../../content/avatar.jpg}};
+        \end{tikzpicture}
+    \end{center}}
+
 \begin{document}
 
 \maketitle
+
+\avatar
 
 \begin{center}
     \begin{tabular}{rl}

--- a/latex/ru/Belyakov_ru.tex
+++ b/latex/ru/Belyakov_ru.tex
@@ -5,6 +5,8 @@
 \usepackage{geometry}
 \usepackage{hyperref}
 \usepackage{enumitem}
+\usepackage{graphicx}
+\usepackage{tikz}
 
 \geometry{a4paper, total={170mm,257mm}, left=20mm, top=20mm}
 
@@ -12,9 +14,19 @@
 \author{Алексей Леонидович Беляков}
 \date{\today}
 
+\newcommand{\avatar}{%
+    \begin{center}
+        \begin{tikzpicture}
+            \clip (0,0) circle (1.5cm);
+            \node at (0,0) {\includegraphics[width=3cm,height=3cm]{../../content/avatar.jpg}};
+        \end{tikzpicture}
+    \end{center}}
+
 \begin{document}
 
 \maketitle
+
+\avatar
 
 \begin{center}
     \begin{tabular}{rl}

--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,4 +1,11 @@
-= Alexey Leonidovich Belyakov 
+= Alexey Leonidovich Belyakov
+
+#align(center)[
+  circle(
+    radius: 2.5cm,
+    fill: image("../../content/avatar.jpg", fit: cover)
+  )
+]
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [leqqrm.t.me](https://leqqrm.t.me)

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,4 +1,11 @@
 = Алексей Леонидович Беляков
+
+#align(center)[
+  circle(
+    radius: 2.5cm,
+    fill: image("../../content/avatar.jpg", fit: cover)
+  )
+]
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: [leqqrm.t.me](https://leqqrm.t.me)
 - **Почта**: [qqrm\@vivaldi.net](mailto:qqrm\@vivaldi.net)


### PR DESCRIPTION
## Summary
- embed avatar at the top of all LaTeX CVs
- embed avatar at the top of all Typst CVs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68811e9c39ec8332ae0501bba79588d8