### PR TITLE
Fix PDF naming in release workflows

### DIFF
--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -18,12 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-cv
+      - name: Prepare release PDFs
+        run: |
+          cp latex/en/Belyakov_en.pdf latex/en/Belyakov_en_latex.pdf
+          cp latex/ru/Belyakov_ru.pdf latex/ru/Belyakov_ru_latex.pdf
+          cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
+          cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
       - name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:
           name: cv-pdfs
           path: |
-            latex/en/Belyakov_en.pdf
-            latex/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
+            latex/en/Belyakov_en_latex.pdf
+            latex/ru/Belyakov_ru_latex.pdf
+            typst/en/Belyakov_en_typst.pdf
+            typst/ru/Belyakov_ru_typst.pdf

--- a/.github/workflows/manual_build_pdf.yml
+++ b/.github/workflows/manual_build_pdf.yml
@@ -16,13 +16,19 @@ jobs:
           sed -i '/^\\author/a \\date{'"$DATE"'}' latex/en/Belyakov_en.tex
           sed -i '/^\\author/a \\date{'"$DATE"'}' latex/ru/Belyakov_ru.tex
       - uses: ./.github/actions/setup-cv
+      - name: Prepare release PDFs
+        run: |
+          cp latex/en/Belyakov_en.pdf latex/en/Belyakov_en_latex.pdf
+          cp latex/ru/Belyakov_ru.pdf latex/ru/Belyakov_ru_latex.pdf
+          cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
+          cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
       - name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:
           name: cv-pdfs-${{ env.DATE }}
           path: |
-            latex/en/Belyakov_en.pdf
-            latex/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
+            latex/en/Belyakov_en_latex.pdf
+            latex/ru/Belyakov_ru_latex.pdf
+            typst/en/Belyakov_en_typst.pdf
+            typst/ru/Belyakov_ru_typst.pdf
 

--- a/.github/workflows/sitegen_release.yml
+++ b/.github/workflows/sitegen_release.yml
@@ -33,16 +33,22 @@ jobs:
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml
       - uses: ./.github/actions/setup-cv
+      - name: Prepare release PDFs
+        run: |
+          cp latex/en/Belyakov_en.pdf latex/en/Belyakov_en_latex.pdf
+          cp latex/ru/Belyakov_ru.pdf latex/ru/Belyakov_ru_latex.pdf
+          cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
+          cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: sitegen-assets
           path: |
             sitegen/target/release/sitegen
-            latex/en/Belyakov_en.pdf
-            latex/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
+            latex/en/Belyakov_en_latex.pdf
+            latex/ru/Belyakov_ru_latex.pdf
+            typst/en/Belyakov_en_typst.pdf
+            typst/ru/Belyakov_ru_typst.pdf
       - name: Delete previous releases
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
@@ -59,8 +65,8 @@ jobs:
           tag_name: sitegen-${{ github.run_number }}
           files: |
             sitegen/target/release/sitegen
-            latex/en/Belyakov_en.pdf
-            latex/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
+            latex/en/Belyakov_en_latex.pdf
+            latex/ru/Belyakov_ru_latex.pdf
+            typst/en/Belyakov_en_typst.pdf
+            typst/ru/Belyakov_ru_typst.pdf
 


### PR DESCRIPTION
## Summary
- ensure release PDFs have distinct names
- copy PDF files with `_latex` and `_typst` suffixes before upload

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68813ae9dea48332943b23648542587a