### PR TITLE
Add circle clipping for avatar

### DIFF
--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,7 +1,10 @@
 = Alexey Leonidovich Belyakov
 
 #align(center)[
-  image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+  #frame(
+    image("../../content/avatar.jpg", width: 5cm, height: 5cm),
+    clip: circle(2.5cm),
+  )
 ]
 
 - **Phone:** +7 (911) 261-70-72

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,7 +1,10 @@
 = Алексей Леонидович Беляков
 
 #align(center)[
-  image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+  #frame(
+    image("../../content/avatar.jpg", width: 5cm, height: 5cm),
+    clip: circle(2.5cm),
+  )
 ]
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: #link("https://leqqrm.t.me")[leqqrm.t.me]


### PR DESCRIPTION
## Summary
- clip avatar image to a circle in Typst templates

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(fails: LaTeX error)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: LaTeX error)*
- `typst compile typst/en/Belyakov_en.typ --root .` *(fails: unknown variable)*
- `typst compile typst/ru/Belyakov_ru.typ --root .` *(fails: unknown variable)*

------
https://chatgpt.com/codex/tasks/task_e_6881637b82888332aab9d759853a3071