### PR TITLE
Fix avatar layout

### DIFF
--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,10 +1,9 @@
 = Alexey Leonidovich Belyakov
 
 #align(center)[
-  #frame(
-    image("../../content/avatar.jpg", width: 5cm, height: 5cm),
-    clip: circle(2.5cm),
-  )
+  #box(width: 5cm, height: 5cm, radius: 2.5cm)[
+    image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+  ]
 ]
 
 - **Phone:** +7 (911) 261-70-72

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,10 +1,9 @@
 = Алексей Леонидович Беляков
 
 #align(center)[
-  #frame(
-    image("../../content/avatar.jpg", width: 5cm, height: 5cm),
-    clip: circle(2.5cm),
-  )
+  #box(width: 5cm, height: 5cm, radius: 2.5cm)[
+    image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+  ]
 ]
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: #link("https://leqqrm.t.me")[leqqrm.t.me]


### PR DESCRIPTION
## Summary
- use a rounded `#box` for the avatar in English and Russian Typst sources

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: Unicode character errors)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68822b2e6ba483329c5ff8ff58885a89