### PR TITLE
Add CV docs link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
 <li><strong>Telegram:</strong> <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
 <li><strong>Email:</strong> qqrm@vivaldi.net</li>
 <li><strong>GitHub:</strong> <a href="https://github.com/qqrm">github.com/qqrm</a></li>
+<li><strong>Docs:</strong> <a href="https://qqrm.github.io/CV/">qqrm.github.io/CV</a></li>
 </ul>
 <p>Languages:</p>
 <ul>

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -16,6 +16,7 @@
 <li><strong>Telegram</strong>: <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
 <li><strong>Почта</strong>: <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
 <li><strong>GitHub</strong>: <a href="https://github.com/qqrm">github.com/qqrm</a></li>
+<li><strong>Docs</strong>: <a href="https://qqrm.github.io/CV/">qqrm.github.io/CV</a></li>
 </ul>
 <p><strong>Языки</strong>:</p>
 <ul>

--- a/latex/en/Belyakov_en.tex
+++ b/latex/en/Belyakov_en.tex
@@ -34,6 +34,7 @@
         \textbf{Telegram:} & \href{https://leqqrm.t.me}{leqqrm.t.me} \\
         \textbf{Email:} & \href{mailto:qqrm@vivaldi.net}{qqrm@vivaldi.net} \\
         \textbf{GitHub:} & \href{https://github.com/qqrm}{github.com/qqrm} \\
+        \textbf{Docs:} & \href{https://qqrm.github.io/CV/}{qqrm.github.io/CV} \\
     \end{tabular}
 \end{center}
 

--- a/latex/ru/Belyakov_ru.tex
+++ b/latex/ru/Belyakov_ru.tex
@@ -34,6 +34,7 @@
         \textbf{Telegram:} & \href{https://leqqrm.t.me}{leqqrm.t.me} \\
         \textbf{Почта:} & \href{mailto:qqrm@vivaldi.net}{qqrm@vivaldi.net} \\
         \textbf{GitHub:} & \href{https://github.com/qqrm}{github.com/qqrm} \\
+        \textbf{Docs:} & \href{https://qqrm.github.io/CV/}{qqrm.github.io/CV} \\
     \end{tabular}
 \end{center}
 

--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -10,6 +10,7 @@
 - **Telegram:** #link("https://leqqrm.t.me")[leqqrm.t.me]
 - **Email:** #link("mailto:qqrm@vivaldi.net")[qqrm\@vivaldi.net]
 - **GitHub:** #link("https://github.com/qqrm")[github.com/qqrm]
+- **Docs:** #link("https://qqrm.github.io/CV/")[qqrm.github.io/CV]
 
 Languages:
 - Russian (Native)

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -9,6 +9,7 @@
 - **Telegram**: #link("https://leqqrm.t.me")[leqqrm.t.me]
 - **Почта**: #link("mailto:qqrm@vivaldi.net")[qqrm\@vivaldi.net]
 - **GitHub**: #link("https://github.com/qqrm")[github.com/qqrm]
+- **Docs**: #link("https://qqrm.github.io/CV/")[qqrm.github.io/CV]
 **Языки**:
 - Русский (родной)
 - Английский (B2 — продвинутый уровень)


### PR DESCRIPTION
## Summary
- add link to the GitHub docs site in English and Russian HTML pages
- add docs link in LaTeX templates
- add docs link in Typst files

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(fails: requires additional LaTeX setup)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: requires additional LaTeX setup)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(failed to run: typst not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882565c11ec8332afdc9a1389c5cadc