### PR TITLE
Fix avatar roundness in Typst

### DIFF
--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,7 +1,7 @@
 = Alexey Leonidovich Belyakov
 
 #align(center)[
-  #box(width: 5cm, height: 5cm, radius: 2.5cm)[
+  #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
     image("../../content/avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,7 +1,7 @@
 = Алексей Леонидович Беляков
 
 #align(center)[
-  #box(width: 5cm, height: 5cm, radius: 2.5cm)[
+  #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
     image("../../content/avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]


### PR DESCRIPTION
## Summary
- make the avatar circular in Typst sources using `clip: true`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(passes)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: Unicode character errors)*

------
https://chatgpt.com/codex/tasks/task_e_688255005a588332be8a57713512573d