### PR TITLE
Fix typst avatar path

### DIFF
--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -2,7 +2,7 @@
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
-    #image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+    #image("avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]
 

--- a/typst/en/avatar.jpg
+++ b/typst/en/avatar.jpg
@@ -1,0 +1,1 @@
+../../content/avatar.jpg

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -2,7 +2,7 @@
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
-    #image("../../content/avatar.jpg", width: 5cm, height: 5cm)
+    #image("avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]
 - **Телефон**: +7 (911) 261-70-72

--- a/typst/ru/avatar.jpg
+++ b/typst/ru/avatar.jpg
@@ -1,0 +1,1 @@
+../../content/avatar.jpg


### PR DESCRIPTION
## Summary
- keep avatar image within Typst project root via symlinks
- update Typst sources to load the avatar from local path

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(fails: PackageError in hyperref)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: PackageError in hyperref)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68827c8830748332b3900f4e23987f54