### PR TITLE
Add workflow to cancel PR checks after merge

### DIFF
--- a/.github/workflows/cancel_pr_checks.yml
+++ b/.github/workflows/cancel_pr_checks.yml
@@ -1,0 +1,34 @@
+name: Cancel PR Checks on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cancel:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const sha = pr.head.sha;
+
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            for (const run of runs.data.workflow_runs) {
+              if (run.head_sha === sha && ['queued', 'in_progress'].includes(run.status)) {
+                github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+              }
+            }
+


### PR DESCRIPTION
## Summary
- cancel all queued or running workflow runs for a PR once it gets merged

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(fails: command not found)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827d9fe1788332984c540ca2ef1456