### PR TITLE
Добавлен кэш APT для GitHub Action

### DIFF
--- a/.github/actions/setup-cv/action.yml
+++ b/.github/actions/setup-cv/action.yml
@@ -3,6 +3,15 @@ description: 'Install dependencies and build both LaTeX and Typst PDFs.'
 runs:
   using: 'composite'
   steps:
+    - name: Cache APT packages
+      id: apt-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          /var/cache/apt/archives
+          /var/lib/apt/lists
+        key: ${{ runner.os }}-apt-latex-${{ hashFiles('.github/actions/setup-cv/action.yml') }}
+        restore-keys: ${{ runner.os }}-apt-latex-
     - name: Install LaTeX packages
       shell: bash
       run: |


### PR DESCRIPTION
## Изменения
- добавлено использование `actions/cache` в `.github/actions/setup-cv/action.yml` для кэширования apt-пакетов

## Тесты
- `cargo test --manifest-path sitegen/Cargo.toml`
- локальная сборка PDF через LaTeX и Typst

------
https://chatgpt.com/codex/tasks/task_e_6882abd8ba808332837fe98857bc9f4d