### PR TITLE
Ignore PDFs and build automatically

### DIFF
--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -1,0 +1,28 @@
+name: Build PDFs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'latex/**/*.tex'
+      - 'typst/**/*.typ'
+  pull_request:
+    paths:
+      - 'latex/**/*.tex'
+      - 'typst/**/*.typ'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-cv
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cv-pdfs
+          path: |
+            latex/en/Belyakov_en.pdf
+            latex/ru/Belyakov_ru.pdf
+            typst/en/Belyakov_en.pdf
+            typst/ru/Belyakov_ru.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.aux
+**/*.pdf
 **/*.fdb_latexmk
 **/*.fls
 **/*.log
@@ -11,6 +12,5 @@ sitegen/target/
 docs/index.html
 docs/avatar.jpg
 latex/**/*.pdf
-
 typst/**/*.pdf
 docs/**/*.pdf


### PR DESCRIPTION
## Summary
- keep PDFs out of version control by ignoring all `*.pdf`
- add `build_pdf` workflow to compile LaTeX and Typst on push and PR

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6882af05fc1c8332866af5c8d76947f2