### PR TITLE
Add job title and date to Typst and HTML

### DIFF
--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -67,6 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         + (today.month() as i32 - start_date.month() as i32);
     let duration_en = format_duration_en(total_months);
     let duration_ru = format_duration_ru(total_months);
+    let date_str = today.format("%Y-%m-%d").to_string();
     // Generate English version
     let markdown_input = fs::read_to_string("README.md")?;
     let parser = Parser::new_ext(&markdown_input, Options::all());
@@ -83,8 +84,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let html_template = format!(
-        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        AVATAR_SRC_EN, html_body
+        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        date_str, AVATAR_SRC_EN, html_body
     );
 
     // Generate Russian version
@@ -102,8 +103,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let html_template_ru = format!(
-        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='../latex/ru/Belyakov_ru.pdf'>Ссылка на PDF</a></em><br /><em><a href='../latex/en/Belyakov_en.pdf'>Ссылка на английский PDF</a></em></p>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='../typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        AVATAR_SRC_RU, html_body_ru
+        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='../latex/ru/Belyakov_ru.pdf'>Ссылка на PDF</a></em><br /><em><a href='../latex/en/Belyakov_en.pdf'>Ссылка на английский PDF</a></em></p>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='../typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        date_str, AVATAR_SRC_RU, html_body_ru
     );
 
     let docs_dir = Path::new("docs");

--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,4 +1,6 @@
 #align(center)[= Alexey Leonidovich Belyakov]
+#align(center)[*Rust Team Lead*]
+#align(center)[#datetime.today().display()]
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,4 +1,6 @@
 #align(center)[= Алексей Леонидович Беляков]
+#align(center)[*Rust Team Lead*]
+#align(center)[#datetime.today().display()]
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[


### PR DESCRIPTION
## Summary
- add position and date lines to Typst CV files
- include job title and current date in generated HTML header

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6882aecebef883329ca760aa47cf9f95