### PR TITLE
Update site to link release PDFs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,14 +73,8 @@ jobs:
       - name: Generate site
         run: ./sitegen
       - uses: ./.github/actions/setup-cv
-      - name: Copy PDFs and README_ru
+      - name: Copy README_ru
         run: |
-          mkdir -p docs/latex/en docs/latex/ru
-          cp latex/en/Belyakov_en.pdf docs/latex/en/
-          cp latex/ru/Belyakov_ru.pdf docs/latex/ru/
-          mkdir -p docs/typst/en docs/typst/ru
-          cp typst/en/Belyakov_en.pdf docs/typst/en/
-          cp typst/ru/Belyakov_ru.pdf docs/typst/ru/
           cp README_ru.md docs/
       - name: Setup Pages
         uses: actions/configure-pages@v5.0.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,18 +8,19 @@
 <body>
 <header>
     <h1>Alexey Belyakov</h1>
+    <p><strong>Rust Team Lead</strong></p>
+    <p>2025-07-24</p>
 </header>
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 <p><em><a href="ru/">Link to russian version</a></em> \
-<em><a href="latex/en/Belyakov_en.pdf">Link to PDF</a></em> \
-<em><a href="latex/ru/Belyakov_ru.pdf">Link to russian PDF</a></em></p>
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf">Link to PDF</a></em> \
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf">Link to russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
-<li><strong>Email:</strong> qqrm@vivaldi.net</li>
+<li><strong>Email:</strong> <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
 <li><strong>GitHub:</strong> <a href="https://github.com/qqrm">github.com/qqrm</a></li>
-<li><strong>Docs:</strong> <a href="https://qqrm.github.io/CV/">qqrm.github.io/CV</a></li>
 </ul>
 <p>Languages:</p>
 <ul>
@@ -27,7 +28,7 @@
 <li>English (B2 — Advanced)</li>
 </ul>
 <p>Work Schedule: Remote work, full-time</p>
-<h1>Objective:</h1>
+<h2>Objective</h2>
 <p>A highly skilled Rust Team Lead with nearly 10 years of software development and system architecture experience. Committed to driving innovation in robust, high-performance systems and empowering teams to deliver impactful solutions. Seeking to leverage deep technical expertise, leadership skills, and microservices best practices to build high-performing development teams, streamline processes, and achieve business objectives in cutting-edge projects.</p>
 <h2>Work Experience</h2>
 <h3>Rust Team Lead @ Inline Group | <a href="https://www.inlinegroup.ru">www.inlinegroup.ru</a></h3>
@@ -171,10 +172,10 @@
 
 </div>
 <footer>
-    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>
-    <p><a href='typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>
-    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
-    <p><a href='typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (Typst EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (Typst RU)</a></p>
 </footer>
 </body>
 </html>

--- a/docs/ru/index.html
+++ b/docs/ru/index.html
@@ -8,16 +8,17 @@
 <body>
 <header>
     <h1>Алексей Беляков</h1>
+    <p><strong>Rust Team Lead</strong></p>
+    <p>2025-07-24</p>
 </header>
 <div class='content'>
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
-<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='../latex/ru/Belyakov_ru.pdf'>Ссылка на PDF</a></em><br /><em><a href='../latex/en/Belyakov_en.pdf'>Ссылка на английский PDF</a></em></p>
+<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf'>Ссылка на PDF</a></em><br /><em><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf'>Ссылка на английский PDF</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
 <li><strong>Почта</strong>: <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
 <li><strong>GitHub</strong>: <a href="https://github.com/qqrm">github.com/qqrm</a></li>
-<li><strong>Docs</strong>: <a href="https://qqrm.github.io/CV/">qqrm.github.io/CV</a></li>
 </ul>
 <p><strong>Языки</strong>:</p>
 <ul>
@@ -161,10 +162,10 @@
 
 </div>
 <footer>
-    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>
-    <p><a href='../typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>
-    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
-    <p><a href='../typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (Typst EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (Typst RU)</a></p>
 </footer>
 </body>
 </html>

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -1,7 +1,7 @@
-use pulldown_cmark::{html::push_html, Options, Parser};
+use chrono::{Datelike, NaiveDate, Utc};
+use pulldown_cmark::{Options, Parser, html::push_html};
 use std::fs;
 use std::path::Path;
-use chrono::{Datelike, NaiveDate, Utc};
 
 fn format_duration_en(total_months: i32) -> String {
     let years = total_months / 12;
@@ -60,8 +60,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
 
-    let start_date = NaiveDate::from_ymd_opt(INLINE_START.0, INLINE_START.1, 1)
-        .expect("Invalid start date");
+    let start_date =
+        NaiveDate::from_ymd_opt(INLINE_START.0, INLINE_START.1, 1).expect("Invalid start date");
     let today = Utc::now().date_naive();
     let total_months = (today.year() - start_date.year()) * 12
         + (today.month() as i32 - start_date.month() as i32);
@@ -69,10 +69,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let duration_ru = format_duration_ru(total_months);
     let date_str = today.format("%Y-%m-%d").to_string();
     // Generate English version
+    let pdf_latex_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf";
+    let pdf_latex_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf";
+    let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf";
+    let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf";
+
     let markdown_input = fs::read_to_string("README.md")?;
     let parser = Parser::new_ext(&markdown_input, Options::all());
     let mut html_body = String::new();
     push_html(&mut html_body, parser);
+    html_body = html_body.replace("./latex/en/Belyakov_en.pdf", pdf_latex_en);
+    html_body = html_body.replace("./latex/ru/Belyakov_ru.pdf", pdf_latex_ru);
     html_body = html_body.replace("./latex/", "latex/");
     html_body = html_body.replace("./README_ru.md", "ru/");
     html_body = html_body.replace(
@@ -84,8 +91,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let html_template = format!(
-        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        date_str, AVATAR_SRC_EN, html_body
+        "<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Alexey Belyakov - CV</title>\n    <link rel='stylesheet' href='style.css'>\n</head>\n<body>\n<header>\n    <h1>Alexey Belyakov</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n{}\n</div>\n<footer>\n    <p><a href='{pdf_latex_en}'>Download PDF (EN)</a></p>\n    <p><a href='{pdf_typst_en}'>Download PDF (Typst EN)</a></p>\n    <p><a href='{pdf_latex_ru}'>Скачать PDF (RU)</a></p>\n    <p><a href='{pdf_typst_ru}'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        date_str,
+        AVATAR_SRC_EN,
+        html_body,
+        pdf_latex_en = pdf_latex_en,
+        pdf_typst_en = pdf_typst_en,
+        pdf_latex_ru = pdf_latex_ru,
+        pdf_typst_ru = pdf_typst_ru,
     );
 
     // Generate Russian version
@@ -93,6 +106,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let parser_ru = Parser::new_ext(&markdown_ru, Options::all());
     let mut html_body_ru = String::new();
     push_html(&mut html_body_ru, parser_ru);
+    html_body_ru = html_body_ru.replace("./latex/en/Belyakov_en.pdf", pdf_latex_en);
+    html_body_ru = html_body_ru.replace("./latex/ru/Belyakov_ru.pdf", pdf_latex_ru);
     html_body_ru = html_body_ru.replace("./latex/", "../latex/");
     html_body_ru = html_body_ru.replace(
         "март 2024 – настоящее время (около 1 года)",
@@ -103,8 +118,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let html_template_ru = format!(
-        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='../latex/ru/Belyakov_ru.pdf'>Ссылка на PDF</a></em><br /><em><a href='../latex/en/Belyakov_en.pdf'>Ссылка на английский PDF</a></em></p>\n{}\n</div>\n<footer>\n    <p><a href='../latex/en/Belyakov_en.pdf'>Download PDF (EN)</a></p>\n    <p><a href='../typst/en/Belyakov_en.pdf'>Download PDF (Typst EN)</a></p>\n    <p><a href='../latex/ru/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>\n    <p><a href='../typst/ru/Belyakov_ru.pdf'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
-        date_str, AVATAR_SRC_RU, html_body_ru
+        "<!DOCTYPE html>\n<html lang='ru'>\n<head>\n    <meta charset='UTF-8'>\n    <title>Алексей Беляков - Резюме</title>\n    <link rel='stylesheet' href='../style.css'>\n</head>\n<body>\n<header>\n    <h1>Алексей Беляков</h1>\n    <p><strong>Rust Team Lead</strong></p>\n    <p>{}</p>\n</header>\n<div class='content'>\n<img class='avatar' src='{}' alt='Avatar'>\n<p><em><a href='../'>Ссылка на английскую версию</a></em><br /><em><a href='{pdf_latex_ru}'>Ссылка на PDF</a></em><br /><em><a href='{pdf_latex_en}'>Ссылка на английский PDF</a></em></p>\n{}\n</div>\n<footer>\n    <p><a href='{pdf_latex_en}'>Download PDF (EN)</a></p>\n    <p><a href='{pdf_typst_en}'>Download PDF (Typst EN)</a></p>\n    <p><a href='{pdf_latex_ru}'>Скачать PDF (RU)</a></p>\n    <p><a href='{pdf_typst_ru}'>Скачать PDF (Typst RU)</a></p>\n</footer>\n</body>\n</html>\n",
+        date_str,
+        AVATAR_SRC_RU,
+        html_body_ru,
+        pdf_latex_ru = pdf_latex_ru,
+        pdf_latex_en = pdf_latex_en,
+        pdf_typst_en = pdf_typst_en,
+        pdf_typst_ru = pdf_typst_ru,
     );
 
     let docs_dir = Path::new("docs");


### PR DESCRIPTION
## Summary
- link PDFs from GitHub release rather than repository
- simplify release workflow step
- inline PDF links in generator

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6882aeab341c8332a5fd5b78340d35c9