### PR TITLE
Auto-detect current job start date

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +184,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +230,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "pulldown-cmark",
+ "regex",
 ]
 
 [[package]]

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 pulldown-cmark = "0.9"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+regex = "1"

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -2,6 +2,7 @@ use pulldown_cmark::{html::push_html, Options, Parser};
 use std::fs;
 use std::path::Path;
 use chrono::{Datelike, NaiveDate, Utc};
+use regex::Regex;
 
 fn format_duration_en(total_months: i32) -> String {
     let years = total_months / 12;
@@ -55,12 +56,40 @@ fn format_duration_ru(total_months: i32) -> String {
     }
 }
 
+fn month_from_english(month: &str) -> Option<u32> {
+    match month {
+        "January" => Some(1),
+        "February" => Some(2),
+        "March" => Some(3),
+        "April" => Some(4),
+        "May" => Some(5),
+        "June" => Some(6),
+        "July" => Some(7),
+        "August" => Some(8),
+        "September" => Some(9),
+        "October" => Some(10),
+        "November" => Some(11),
+        "December" => Some(12),
+        _ => None,
+    }
+}
+
+fn read_inline_start() -> Option<(i32, u32)> {
+    let content = fs::read_to_string("README.md").ok()?;
+    let re = Regex::new(r"\*([A-Za-z]+)\s+(\d{4})\s+–\s+Present").ok()?;
+    let caps = re.captures(&content)?;
+    let month = month_from_english(&caps[1])?;
+    let year: i32 = caps[2].parse().ok()?;
+    Some((year, month))
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     const AVATAR_SRC_EN: &str = "avatar.jpg";
     const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
 
-    let start_date = NaiveDate::from_ymd_opt(INLINE_START.0, INLINE_START.1, 1)
+    let inline_start = read_inline_start().unwrap_or(INLINE_START);
+    let start_date = NaiveDate::from_ymd_opt(inline_start.0, inline_start.1, 1)
         .expect("Invalid start date");
     let today = Utc::now().date_naive();
     let total_months = (today.year() - start_date.year()) * 12


### PR DESCRIPTION
## Summary
- read current job start date from `README.md`
- add `regex` crate to site generator

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails: Unicode character errors)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68848efd59cc833286f7507cd5387e39