### PR TITLE
Fix release workflow path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
         uses: actions/download-artifact@v4.3.0
         with:
           name: sitegen-assets
+      - name: Move sitegen binary
+        run: mv sitegen/target/release/sitegen ./sitegen
       - name: Make binary executable
         run: chmod +x sitegen
       - name: Generate site


### PR DESCRIPTION
## Summary
- ensure the release workflow uses the downloaded binary

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6884ba4a46c483329236f51ec4921f70