### PR TITLE
Update PDF links and site reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 - [English CV](./cv.md)
 - [Русская версия CV](./cv.ru.md)
-- [PDF (en)](./latex/en/Belyakov_en.pdf)
-- [PDF (ru)](./latex/ru/Belyakov_ru.pdf)
+- [PDF (en)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf)
+- [PDF (ru)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf)
+- [Static site](https://qqrm.github.io/CV/)
 
 Инструкции по сборке находятся в директории `sitegen` и `latex`/`typst`.

--- a/README_ru.md
+++ b/README_ru.md
@@ -4,7 +4,8 @@
 
 - [CV на английском](./cv.md)
 - [Русская версия CV](./cv.ru.md)
-- [PDF на английском](./latex/en/Belyakov_en.pdf)
-- [PDF на русском](./latex/ru/Belyakov_ru.pdf)
+- [PDF на английском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf)
+- [PDF на русском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf)
+- [Сайт](https://qqrm.github.io/CV/)
 
 Подробности сборки смотрите в каталоге `sitegen` и папках `latex`/`typst`.


### PR DESCRIPTION
## Summary
- link README PDFs to release assets instead of repo paths
- add static site links

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: `read_inline_start` redefined)*
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails with Unicode character errors)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68850ddd2b58833289c83bdaf770c80d