### PR TITLE
Update DevOps guide

### DIFF
--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -1,0 +1,12 @@
+# DevOps Guide
+
+This document describes how we work with CI/CD and infrastructure in our projects.
+
+## Merge Request checks behavior
+- If a check fails and new commits are added to the MR, all checks should restart automatically.
+- If this does not happen, manually rerun the pipeline or ensure it is configured to trigger on new commits.
+
+## General recommendations
+- Use `.gitlab-ci.yml` or a similar configuration to automatically run tests and builds.
+- Keep all secrets in CI/CD environment variables, not in the repository.
+- Before merging into the main branch, make sure all checks have passed.


### PR DESCRIPTION
## Summary
- rename DevOps guide to remove mention of a nonexistent organization
- keep documentation in English as requested

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: `read_inline_start` defined multiple times)*
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(succeeds)*
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex` *(fails with Unicode errors)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ecac878c83328e023b51a6823e1c