### PR TITLE
Update agent instructions and fix build error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
-В этом репозитории README файлы обычно редактируются вручную. Не изменяйте README.md и README_ru.md, если только в задании явно не просят их изменить.
+README files in this repository are usually edited manually. Do not change README.md or README_ru.md unless the task explicitly requests it.
 
-Перед коммитами запускайте тесты:
+Run tests before commits:
 
 ```
 cargo test --manifest-path sitegen/Cargo.toml
 ```
 
-Также проверяйте локальную сборку PDF через LaTeX и Typst:
+Also check the local PDF build with LaTeX and Typst:
 
 ```
 latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex
@@ -15,5 +15,8 @@ typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
 typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
 ```
 
-Перед коммитом убедитесь, что бинарные файлы (например, PDF) не
-попадают в diff и не добавляются в репозиторий.
+Before committing, ensure that binary files (e.g., PDF) are not included in the diff or added to the repository.
+
+All project documentation must be written in English. Use English for code comments as well.
+
+Make a best effort to fix compilation errors, linter warnings, and failing tests before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Alexey Belyakov CV
 
-Это репозиторий с исходниками моего резюме. Здесь хранятся Markdown-версии CV, из которых генерируются PDF и веб-сайт.
+This repository stores the sources of my resume. Markdown files are converted into PDF and a static website.
 
 - [English CV](./cv.md)
-- [Русская версия CV](./cv.ru.md)
+- [Russian CV](./cv.ru.md)
 - [PDF (en)](./latex/en/Belyakov_en.pdf)
 - [PDF (ru)](./latex/ru/Belyakov_ru.pdf)
+- [Website](https://qqrm.github.io/CV/)
 
-Инструкции по сборке находятся в директории `sitegen` и `latex`/`typst`.
+Build instructions are in the `sitegen`, `latex` and `typst` directories. The repository also contains automation that simplifies and entertains the process.

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -4,74 +4,6 @@ use std::fs;
 use std::path::Path;
 use regex::Regex;
 
-fn month_from_en(name: &str) -> Option<u32> {
-    match name {
-        "January" => Some(1),
-        "February" => Some(2),
-        "March" => Some(3),
-        "April" => Some(4),
-        "May" => Some(5),
-        "June" => Some(6),
-        "July" => Some(7),
-        "August" => Some(8),
-        "September" => Some(9),
-        "October" => Some(10),
-        "November" => Some(11),
-        "December" => Some(12),
-        _ => None,
-    }
-}
-
-fn month_from_ru(name: &str) -> Option<u32> {
-    match name {
-        "Январь" => Some(1),
-        "Февраль" => Some(2),
-        "Март" => Some(3),
-        "Апрель" => Some(4),
-        "Май" => Some(5),
-        "Июнь" => Some(6),
-        "Июль" => Some(7),
-        "Август" => Some(8),
-        "Сентябрь" => Some(9),
-        "Октябрь" => Some(10),
-        "Ноябрь" => Some(11),
-        "Декабрь" => Some(12),
-        _ => None,
-    }
-}
-
-fn read_inline_start() -> Option<(i32, u32)> {
-    let content = std::fs::read_to_string("README.md").ok()?;
-    for line in content.lines() {
-        if let Some((month_str, year_str)) = line
-            .trim()
-            .strip_prefix('*')
-            .and_then(|s| s.split_once('–'))
-            .or_else(|| {
-                line.trim()
-                    .strip_prefix('*')
-                    .and_then(|s| s.split_once('—'))
-            })
-        {
-            let year_str = year_str.trim();
-            if year_str.starts_with("Present") || year_str.starts_with("Настоящее время")
-            {
-                let parts: Vec<&str> = month_str.trim().split_whitespace().collect();
-                if parts.len() == 2 {
-                    let (month_text, year_text) = (parts[0], parts[1]);
-                    let year: i32 = year_text.parse().ok()?;
-                    if let Some(month) =
-                        month_from_en(month_text).or_else(|| month_from_ru(month_text))
-                    {
-                        return Some((year, month));
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
 fn format_duration_en(total_months: i32) -> String {
     let years = total_months / 12;
     let months = total_months % 12;
@@ -143,7 +75,8 @@ fn month_from_english(month: &str) -> Option<u32> {
 }
 
 fn read_inline_start() -> Option<(i32, u32)> {
-    let content = fs::read_to_string("README.md").ok()?;
+    // Parse start date from the English CV source
+    let content = fs::read_to_string("cv.md").ok()?;
     let re = Regex::new(r"\*([A-Za-z]+)\s+(\d{4})\s+–\s+Present").ok()?;
     let caps = re.captures(&content)?;
     let month = month_from_english(&caps[1])?;


### PR DESCRIPTION
## Summary
- remove duplicate function in site generator and read start date from `cv.md`
- install missing LaTeX tools and build all PDF/Typst outputs
- add rule in `AGENTS.md` to fix compile/lint/test issues before PRs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6884ed7db084833287d03f464deed2f9