### PR TITLE
Fix release workflow sitegen binary path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,11 @@ jobs:
         with:
           name: sitegen-assets
       - name: Move sitegen binary
-        run: mv sitegen/target/release/sitegen ./sitegen
+        run: mv sitegen/target/release/sitegen ./sitegen_bin
       - name: Make binary executable
-        run: chmod +x sitegen
+        run: chmod +x sitegen_bin
       - name: Generate site
-        run: ./sitegen
+        run: ./sitegen_bin
       - uses: ./.github/actions/setup-cv
       - name: Copy README_ru
         run: |
@@ -100,7 +100,7 @@ jobs:
         with:
           tag_name: sitegen-${{ github.run_number }}
           files: |
-            sitegen
+            sitegen_bin
             latex/en/Belyakov_en_latex.pdf
             latex/ru/Belyakov_ru_latex.pdf
             typst/en/Belyakov_en_typst.pdf


### PR DESCRIPTION
## Summary
- avoid naming conflict with sitegen directory in release workflow
- run built binary from `sitegen_bin`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex` *(fails: `latexmk` not found)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: `typst` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886181025648332a4aff62ccfeb72a0