### PR TITLE
Fix inline start parsing

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,35 +175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +192,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "pulldown-cmark",
- "regex",
 ]
 
 [[package]]

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2024"
 [dependencies]
 pulldown-cmark = "0.9"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-regex = "1"

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -2,7 +2,6 @@ use chrono::{Datelike, NaiveDate, Utc};
 use pulldown_cmark::{Options, Parser, html::push_html};
 use std::fs;
 use std::path::Path;
-use regex::Regex;
 
 fn month_from_en(name: &str) -> Option<u32> {
     match name {
@@ -41,7 +40,7 @@ fn month_from_ru(name: &str) -> Option<u32> {
 }
 
 fn read_inline_start() -> Option<(i32, u32)> {
-    let content = std::fs::read_to_string("README.md").ok()?;
+    let content = std::fs::read_to_string("cv.md").ok()?;
     for line in content.lines() {
         if let Some((month_str, year_str)) = line
             .trim()


### PR DESCRIPTION
## Summary
- read start date from `cv.md` instead of `README`
- drop unused regex dependency

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -xelatex -cd latex/ru/Belyakov_ru.tex` *(fails: Missing characters in font)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68861b47fb648332bcfe07ab676aaca2