### PR TITLE
Generate role pages and PDFs

### DIFF
--- a/.github/actions/setup-cv/action.yml
+++ b/.github/actions/setup-cv/action.yml
@@ -35,3 +35,14 @@ runs:
     - name: Build Typst Russian PDF
       shell: bash
       run: typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
+    - name: Build role-based Typst PDFs
+      shell: bash
+      run: |
+        for role in tl em hod tech; do
+          name=$(grep "^$role =" roles.toml | cut -d '"' -f2)
+          sed "s/Rust Team Lead/$name/" typst/en/Belyakov_en.typ > temp.typ
+          typst compile temp.typ "typst/en/Belyakov_en_${role}.pdf"
+          sed "s/Rust Team Lead/$name/" typst/ru/Belyakov_ru.typ > temp.typ
+          typst compile temp.typ "typst/ru/Belyakov_ru_${role}.pdf"
+        done
+        rm temp.typ

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
           cp latex/ru/Belyakov_ru.pdf latex/ru/Belyakov_ru_latex.pdf
           cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
           cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
+          for role in tl em hod tech; do
+            cp typst/en/Belyakov_en_${role}.pdf typst/en/Belyakov_en_${role}_typst.pdf
+            cp typst/ru/Belyakov_ru_${role}.pdf typst/ru/Belyakov_ru_${role}_typst.pdf
+          done
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.2
         with:
@@ -54,6 +58,14 @@ jobs:
             latex/ru/Belyakov_ru_latex.pdf
             typst/en/Belyakov_en_typst.pdf
             typst/ru/Belyakov_ru_typst.pdf
+            typst/en/Belyakov_en_tl_typst.pdf
+            typst/en/Belyakov_en_em_typst.pdf
+            typst/en/Belyakov_en_hod_typst.pdf
+            typst/en/Belyakov_en_tech_typst.pdf
+            typst/ru/Belyakov_ru_tl_typst.pdf
+            typst/ru/Belyakov_ru_em_typst.pdf
+            typst/ru/Belyakov_ru_hod_typst.pdf
+            typst/ru/Belyakov_ru_tech_typst.pdf
 
   site:
     needs: build_sitegen
@@ -105,3 +117,11 @@ jobs:
             latex/ru/Belyakov_ru_latex.pdf
             typst/en/Belyakov_en_typst.pdf
             typst/ru/Belyakov_ru_typst.pdf
+            typst/en/Belyakov_en_tl_typst.pdf
+            typst/en/Belyakov_en_em_typst.pdf
+            typst/en/Belyakov_en_hod_typst.pdf
+            typst/en/Belyakov_en_tech_typst.pdf
+            typst/ru/Belyakov_ru_tl_typst.pdf
+            typst/ru/Belyakov_ru_em_typst.pdf
+            typst/ru/Belyakov_ru_hod_typst.pdf
+            typst/ru/Belyakov_ru_tech_typst.pdf

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -230,13 +230,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fs::create_dir_all(docs_dir)?;
     }
     fs::copy("content/avatar.jpg", docs_dir.join("avatar.jpg"))?;
-    fs::write(docs_dir.join("index.html"), html_template)?;
+    fs::write(docs_dir.join("index.html"), &html_template)?;
 
     let ru_dir = docs_dir.join("ru");
     if !ru_dir.exists() {
         fs::create_dir_all(&ru_dir)?;
     }
-    fs::write(ru_dir.join("index.html"), html_template_ru)?;
+    fs::write(ru_dir.join("index.html"), &html_template_ru)?;
+
+    // Generate role-specific copies for both languages
+    for role in roles.keys() {
+        let en_role_dir = docs_dir.join(role);
+        if !en_role_dir.exists() {
+            fs::create_dir_all(&en_role_dir)?;
+        }
+        fs::write(en_role_dir.join("index.html"), &html_template)?;
+
+        let ru_role_dir = ru_dir.join(role);
+        if !ru_role_dir.exists() {
+            fs::create_dir_all(&ru_role_dir)?;
+        }
+        fs::write(ru_role_dir.join("index.html"), &html_template_ru)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add directories for each role when generating docs
- build role-based Typst PDFs in CI
- include new PDFs in releases

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

------
https://chatgpt.com/codex/tasks/task_e_6887e9a9d40883328ba2d74ef70c8f45