### PR TITLE
Add JSON template generator

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +232,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -244,6 +268,7 @@ dependencies = [
  "chrono",
  "pulldown-cmark",
  "serde",
+ "serde_json",
  "toml",
 ]
 

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -8,3 +8,8 @@ pulldown-cmark = "0.9"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[bin]]
+name = "templategen"
+path = "src/templategen.rs"

--- a/sitegen/src/templategen.rs
+++ b/sitegen/src/templategen.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct CvJson {
+    en_markdown: String,
+    ru_markdown: String,
+    roles: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct Roles {
+    roles: BTreeMap<String, String>,
+}
+
+fn main() -> std::io::Result<()> {
+    let en_markdown = fs::read_to_string("cv.md")?;
+    let ru_markdown = fs::read_to_string("cv.ru.md")?;
+    let roles_content = fs::read_to_string("roles.toml")?;
+    let roles: Roles = toml::from_str(&roles_content).expect("invalid roles.toml");
+
+    let cv = CvJson {
+        en_markdown,
+        ru_markdown,
+        roles: roles.roles.clone(),
+    };
+    fs::write("cv.json", serde_json::to_string_pretty(&cv).unwrap())?;
+
+    generate_templates(&cv)?;
+    Ok(())
+}
+
+fn generate_templates(cv: &CvJson) -> std::io::Result<()> {
+    let template_en = fs::read_to_string("typst/en/Belyakov_en.typ")?;
+    let template_ru = fs::read_to_string("typst/ru/Belyakov_ru.typ")?;
+    let latex_en = fs::read_to_string("latex/en/Belyakov_en.tex")?;
+    let latex_ru = fs::read_to_string("latex/ru/Belyakov_ru.tex")?;
+
+    for (slug, role) in &cv.roles {
+        let dir_te = Path::new("typst/en").join(slug);
+        let dir_tr = Path::new("typst/ru").join(slug);
+        let dir_le = Path::new("latex/en").join(slug);
+        let dir_lr = Path::new("latex/ru").join(slug);
+        fs::create_dir_all(&dir_te)?;
+        fs::create_dir_all(&dir_tr)?;
+        fs::create_dir_all(&dir_le)?;
+        fs::create_dir_all(&dir_lr)?;
+
+        fs::write(dir_te.join("Belyakov_en.typ"), template_en.replace("Rust Team Lead", role))?;
+        fs::write(dir_tr.join("Belyakov_ru.typ"), template_ru.replace("Rust Team Lead", role))?;
+        fs::write(dir_le.join("Belyakov_en.tex"), latex_en.replace("Rust Team Lead", role))?;
+        fs::write(dir_lr.join("Belyakov_ru.tex"), latex_ru.replace("Rust Team Lead", role))?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add serde_json dependency and `templategen` binary
- generate JSON from markdown and output role-specific templates

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68886214d0f083328b5c03cdd4449e1b