### PR TITLE
Add role-specific Typst links

### DIFF
--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -240,17 +240,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate role-specific copies for both languages
     for role in roles.keys() {
+        let pdf_typst_en_role = format!(
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_{}_typst.pdf",
+            role
+        );
+        let pdf_typst_ru_role = format!(
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_{}_typst.pdf",
+            role
+        );
+
         let en_role_dir = docs_dir.join(role);
         if !en_role_dir.exists() {
             fs::create_dir_all(&en_role_dir)?;
         }
-        fs::write(en_role_dir.join("index.html"), &html_template)?;
+        let role_template_en = html_template
+            .replace(pdf_typst_en, &pdf_typst_en_role)
+            .replace(pdf_typst_ru, &pdf_typst_ru_role);
+        fs::write(en_role_dir.join("index.html"), role_template_en)?;
 
         let ru_role_dir = ru_dir.join(role);
         if !ru_role_dir.exists() {
             fs::create_dir_all(&ru_role_dir)?;
         }
-        fs::write(ru_role_dir.join("index.html"), &html_template_ru)?;
+        let role_template_ru = html_template_ru
+            .replace(pdf_typst_en, &pdf_typst_en_role)
+            .replace(pdf_typst_ru, &pdf_typst_ru_role);
+        fs::write(ru_role_dir.join("index.html"), role_template_ru)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- update `sitegen` to generate role-specific HTML
- point role pages at role-specific Typst PDFs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `latexmk -pdf -quiet -cd latex/en/Belyakov_en.tex`
- `latexmk -pdf -quiet -cd latex/ru/Belyakov_ru.tex`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688a0eac1a308332b44fb4e6a3734531