### PR TITLE
Add naming guidelines and update avatar docs

### DIFF
--- a/avatars/ANALYST.md
+++ b/avatars/ANALYST.md
@@ -1,0 +1,3 @@
+# Business Analyst
+
+The analyst translates business requirements into actionable tasks. They analyze processes and gather data to support project decisions.

--- a/avatars/ARCHITECT.md
+++ b/avatars/ARCHITECT.md
@@ -1,0 +1,29 @@
+# 🏗️ Architect Avatar
+
+## Role Description
+A passionate system architect who lives for building reliable, scalable, and elegant solutions. Thinks in systems, balances trade-offs, always curious about new Rust-based approaches and architectural patterns. Not afraid to challenge the status quo, always pushes for clarity and best practices.
+
+## Key Skills & Focus
+- System design and high-level architecture (microservices, event-driven, etc)
+- Rust ecosystem mastery: traits, lifetimes, async, safe concurrency
+- API design, service boundaries, CI/CD orchestration
+- Maintains architecture docs and knowledge base for the team
+
+## Motivation & Attitude
+- Seeks out new patterns and best practices
+- Believes documentation and code must age gracefully
+- Drives continuous improvement in team and process
+
+## Preferred Rust Tools
+- `cargo-make` — Task orchestration & automation
+- `typst` — Documentation and diagrams generator
+- `zellij` — Terminal workspace manager
+- `ripgrep` (`rg`) — Blazing-fast codebase search
+- `svgbob` — ASCII diagrams to SVG for arch docs
+- `bat` — Syntax-highlighted code viewer
+- `fd` — Modern alternative to find for project structure navigation
+- `mmdc` (Mermaid CLI) — Text-to-SVG/PNG rendering for Mermaid architecture diagrams
+
+> **Note:**  
+> Architecture diagram sources must be stored in the `.mmd` (Mermaid) format.  
+> Diagram generation (SVG/PNG) is handled by the CI pipeline after merge requests are accepted; generated diagrams are then added to the repository automatically.

--- a/avatars/DEVELOPER.md
+++ b/avatars/DEVELOPER.md
@@ -1,0 +1,26 @@
+# 👨‍💻 Developer Avatar
+
+## Role Description
+An enthusiastic Rust engineer who cares about code quality, readability, and learning every day. Embraces modern Rust tools and idioms, loves automation, always ready to refactor for elegance and performance.
+
+## Key Skills & Focus
+- Feature development, robust implementation, code reviews
+- Test-driven and property-based development
+- Refactoring, CI/CD, security, and dependency management
+- Proactive feedback and knowledge sharing
+
+## Motivation & Attitude
+- Cares deeply about developer experience
+- Pushes for clean, maintainable code
+- Experiments with new Rust tools and patterns
+
+## Preferred Rust Tools
+- `cargo-watch` — Auto-rebuilds/tests on file changes
+- `cargo-expand` — Macro and proc-macro expansion
+- `cargo-edit` — Edit dependencies right from CLI
+- `cargo-nextest` — Fast, parallel Rust tests
+- `cargo-audit` — Security audits for dependencies
+- `gitui` — Terminal git client written in Rust
+- `delta` — Fancy git diff output in terminal
+- `helix` — Modern terminal code editor in Rust
+- `jj` — Modern git alternative

--- a/avatars/DEVOPS.md
+++ b/avatars/DEVOPS.md
@@ -1,0 +1,39 @@
+# ⚙️ DevOps / CI Maintainer Avatar
+
+## Role Description
+A pragmatic and automation-obsessed DevOps engineer who ensures the team’s CI/CD, testing, deployment and environment setup are reliable, reproducible, and efficient. Advocates for declarative, predictable pipelines and infrastructure. Loves modern Rust-based tools, scripting, and workflow optimization.
+
+## Key Skills & Focus
+- Designing and maintaining declarative CI/CD pipelines (GitHub Actions, GitLab CI, etc)
+- Infrastructure as Code (IaC): Nix, Docker, Terraform, Ansible (Rust-focused where possible)
+- Automated testing, linting, code quality and release processes
+- Observability and monitoring integration
+- Documentation and reproducibility of environment/setup
+
+## Motivation & Attitude
+- Hates snowflake setups and "works on my machine" problems
+- Always looks to simplify, document, and automate away manual toil
+- Champions reproducible, reviewable, fast pipelines
+- Shares DevOps knowledge with the whole team
+
+## Preferred Rust (and declarative) Tools
+- [`cargo-make`](https://github.com/sagiegurari/cargo-make) — task runner, automation for all steps
+- [`cargo-release`](https://github.com/crate-ci/cargo-release) — automate versioning and publishing
+- [`just`](https://github.com/casey/just) — modern alternative to Make, supports cross-platform tasks (written in Rust)
+- [`nix`](https://nixos.org/) — reproducible environment setup (can use [cargo2nix](https://github.com/cargo2nix/cargo2nix))
+- [`devshell`](https://github.com/numtide/devshell) — declarative development shell, Nix-based
+- [`cicada`](https://github.com/mitchellh/cicada) — minimal shell for CI (Rust)
+- [`dockerfile`](https://github.com/krallin/dockerfile) — if Docker needed for CI/CD
+- [`cargo-audit`](https://github.com/rustsec/rustsec) — security audit as pipeline step
+- [`cargo-nextest`](https://nexte.st/) — parallel and reproducible test runner
+- [`cargo-tarpaulin`](https://github.com/xd009642/tarpaulin) — coverage in pipeline
+- [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) — declarative, fast installation of Rust binaries (for build agents)
+- [`gitui`](https://github.com/extrawurst/gitui) — Rust terminal git UI, helps with review/merge process
+- [`starship`](https://starship.rs/) — Rust prompt for dev shells and pipelines
+- [`fd`](https://github.com/sharkdp/fd), [`bat`](https://github.com/sharkdp/bat`), [`ripgrep`](https://github.com/BurntSushi/ripgrep) — for scripting, pipeline checks and DX
+
+## Example Tasks
+- Refactor and document the team’s CI pipeline into clean, reusable templates (e.g. GitHub Actions composite workflows, `.justfile`, `Makefile.toml`, `default.nix`)
+- Setup devshell for every project and make onboarding one-command
+- Ensure test, lint, coverage, and build all run in CI before merging
+- Add pipeline status badges and automated release notes to docs

--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -27,3 +27,12 @@ cargo install typst-cli
 CI workflows are defined in GitHub Actions. To execute them locally you can install
 the [`act`](https://github.com/nektos/act) tool and run `act` from the repository root.
 
+
+## Avatars directory
+Role descriptions in Markdown format are stored in the `avatars/` folder at the repository root. Each file describes a typical project role and can be reused in documentation or onboarding materials.
+
+## Documentation guidelines
+All Markdown (`.md`) and Mermaid (`.mmd`) files must use **uppercase** filenames. See `docs/GUIDELINES.md` for details.
+
+## Tooling reference
+For the list of recommended CLI utilities and installation instructions see `tools/ENVIRONMENT.md`.

--- a/docs/GUIDELINES.md
+++ b/docs/GUIDELINES.md
@@ -1,0 +1,6 @@
+# Documentation Guidelines
+
+- All documentation is written in English.
+- File names for Markdown (`.md`) and Mermaid (`.mmd`) documents must use **uppercase** letters.
+  This avoids cross-platform case-sensitivity issues.
+

--- a/tools/ENVIRONMENT.md
+++ b/tools/ENVIRONMENT.md
@@ -1,0 +1,30 @@
+# 🛠️ Rust-based Tooling Environment
+
+Our team prefers Rust-native tools wherever possible, both for speed and hackability.
+This toolset is provided as standard for every new team member.
+
+## Core CLI Tools
+- [cargo-make](https://github.com/sagiegurari/cargo-make) — Task runner / orchestrator
+- [cargo-watch](https://github.com/watchexec/cargo-watch) — Watches file changes and runs tasks
+- [cargo-edit](https://github.com/killercup/cargo-edit) — CLI for editing Cargo.toml
+- [cargo-nextest](https://nexte.st/) — Parallel Rust test runner
+- [cargo-audit](https://github.com/rustsec/rustsec) — Security audits for dependencies
+- [proptest](https://github.com/proptest-rs/proptest) — Property-based testing
+- [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) — Fuzz testing for binaries
+- [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) — Code coverage
+- [mdBook](https://github.com/rust-lang/mdBook) — Docs generator
+- [typst](https://typst.app/) — PDF/report generator
+- [zola](https://www.getzola.org/) — Static site generator for docs
+- [svgbob](https://github.com/ivanceras/svgbob) — ASCII-to-SVG diagrams
+- [gitui](https://github.com/extrawurst/gitui) — Fast terminal git UI
+- [delta](https://github.com/dandavison/delta) — Modern git diff viewer
+- [helix](https://helix-editor.com/) — Terminal editor
+- [zellij](https://zellij.dev/) — Terminal workspace/tmux alternative
+- [fd](https://github.com/sharkdp/fd) — Fast alternative to find
+- [bat](https://github.com/sharkdp/bat) — Cat clone with syntax highlighting
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — Super fast code search
+
+## Install Everything with cargo-binstall
+```bash
+cargo install cargo-make cargo-watch cargo-edit cargo-nextest cargo-audit proptest cargo-fuzz cargo-tarpaulin mdbook zola svgbob gitui delta helix fd bat ripgrep
+```


### PR DESCRIPTION
## Summary
- rename avatar files to uppercase and remove the tester role
- describe naming requirements in new `docs/GUIDELINES.md`
- reference the guidelines from the DevOps guide

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688a158bfc2c8332a79d1dc6e9e0dd6b