### PR TITLE
Move architecture diagrams into dedicated files

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,23 +5,9 @@ This document outlines how the resume is generated and how the CI/CD pipeline op
 ## CV Generation Workflow
 The `sitegen` tool transforms Markdown and Typst sources into HTML pages and PDF files.
 
-```mermaid
-flowchart TD
-    A[Markdown sources] --> B[sitegen]
-    B --> C[HTML output]
-    B --> D[Typst PDFs]
-    C --> E[docs/ folder]
-    D --> E
-```
+![CV generation workflow](diagrams/CV_GENERATION.svg)
 
 ## CI/CD Pipeline
 GitHub Actions automate checks, merging and releases.
 
-```mermaid
-flowchart TD
-    P[Pull request] --> Q[PR Checks]
-    Q -->|success| M[Auto Merge]
-    Q -->|failure| P
-    M --> R[Release]
-    R --> S[Publish site and PDFs]
-```
+![CI/CD pipeline](diagrams/CI_PIPELINE.svg)

--- a/docs/diagrams/CI_PIPELINE.MMD
+++ b/docs/diagrams/CI_PIPELINE.MMD
@@ -1,0 +1,7 @@
+flowchart TD
+    P[Pull request] --> Q[PR Checks]
+    Q -->|success| M[Auto Merge]
+    Q -->|failure| P
+    M --> R[Release]
+    R --> S[Publish site and PDFs]
+

--- a/docs/diagrams/CV_GENERATION.MMD
+++ b/docs/diagrams/CV_GENERATION.MMD
@@ -1,0 +1,7 @@
+flowchart TD
+    A[Markdown sources] --> B[sitegen]
+    B --> C[HTML output]
+    B --> D[Typst PDFs]
+    C --> E[docs/ folder]
+    D --> E
+


### PR DESCRIPTION
## Summary
- move mermaid diagrams to `docs/diagrams`
- update `docs/architecture.md` to reference generated SVGs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

------
https://chatgpt.com/codex/tasks/task_e_688b86572f0483329e250cfd1658d20d