### PR TITLE
Restrict CI to single trusted user

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -23,6 +23,10 @@ jobs:
               core.info('No pull request associated with this run.');
               return;
             }
+            if (pr.user.login !== 'QQRM') {
+              core.info('PR author not allowed. Skipping merge.');
+              return;
+            }
             const { owner, repo } = context.repo;
             const sha = context.payload.workflow_run.head_sha;
             const checks = await github.rest.checks.listForRef({ owner, repo, ref: sha });

--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -14,8 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Security check
+        id: security
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.user.login }}" = "QQRM" ]; then
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip untrusted PR
+        if: steps.security.outputs.authorized != 'true'
+        run: echo "Pipeline disabled for untrusted author."
       - uses: ./.github/actions/setup-cv
+        if: steps.security.outputs.authorized == 'true'
       - name: Upload PDFs
+        if: steps.security.outputs.authorized == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cv-pdfs

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -8,7 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Security check
+        id: security
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.user.login }}" = "QQRM" ]; then
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip untrusted PR
+        if: steps.security.outputs.authorized != 'true'
+        run: echo "Pipeline disabled for untrusted author."
       - id: filter
+        if: steps.security.outputs.authorized == 'true'
         uses: dorny/paths-filter@v2
         with:
           filters: |
@@ -18,14 +34,14 @@ jobs:
               - 'sitegen/**'
               - 'Cargo.toml'
       - uses: actions-rs/toolchain@v1
-        if: steps.filter.outputs.rust == 'true'
+        if: steps.security.outputs.authorized == 'true' && steps.filter.outputs.rust == 'true'
         with:
           toolchain: stable
           profile: minimal
           override: true
       - name: Cargo build
-        if: steps.filter.outputs.rust == 'true'
+        if: steps.security.outputs.authorized == 'true' && steps.filter.outputs.rust == 'true'
         run: cargo build --manifest-path sitegen/Cargo.toml
       - name: Build PDFs
-        if: steps.filter.outputs.typst == 'true'
+        if: steps.security.outputs.authorized == 'true' && steps.filter.outputs.typst == 'true'
         uses: ./.github/actions/setup-cv

--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -11,6 +11,10 @@ This document describes how we work with CI/CD and infrastructure in our project
 - Keep all secrets in CI/CD environment variables, not in the repository.
 - Before merging into the main branch, make sure all checks have passed.
 
+### Security check
+All automated workflows start with a security step. If the author of a pull
+request is not `QQRM`, the pipeline stops immediately and no jobs run.
+
 ## Automatic pull request merging
 - The `.github/workflows/auto_merge.yml` workflow merges pull requests as soon as all checks succeed.
 - Do not remove or disable this workflow. Auto-merge helps keep the main branch healthy.


### PR DESCRIPTION
## Summary
- remove `.github/trusted-users.txt`
- add security check to workflows that only allows user `QQRM`
- update DevOps guide to document the new rule

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688b8917bebc8332a798d7da2842474f