### PR TITLE
Limit CI to qqrm PRs

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -24,6 +24,16 @@ jobs:
               return;
             }
             const { owner, repo } = context.repo;
+            const fullPr = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number
+            });
+            const allowedAuthors = ['qqrm'];
+            if (!allowedAuthors.includes(fullPr.data.user.login)) {
+              core.info(`PR author ${fullPr.data.user.login} is not allowed to auto-merge.`);
+              return;
+            }
             const sha = context.payload.workflow_run.head_sha;
             const checks = await github.rest.checks.listForRef({ owner, repo, ref: sha });
             const failed = checks.data.check_runs.some(c => ['failure', 'cancelled', 'timed_out'].includes(c.conclusion));

--- a/.github/workflows/build_pdf.yml
+++ b/.github/workflows/build_pdf.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'push' || github.event.pull_request.user.login == 'qqrm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cancel_pr_checks.yml
+++ b/.github/workflows/cancel_pr_checks.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cancel:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'qqrm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6.4.1

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   check:
+    if: github.event.pull_request.user.login == 'qqrm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/restrict_pr_authors.yml
+++ b/.github/workflows/restrict_pr_authors.yml
@@ -1,0 +1,26 @@
+name: Restrict PR Authors
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const allowedAuthors = ['qqrm'];
+            const author = context.payload.pull_request.user.login;
+            if (!allowedAuthors.includes(author)) {
+              core.info(`Closing unauthorized pull request from ${author}`);
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                state: 'closed'
+              });
+              core.setFailed('Unauthorized pull request');
+            }
+


### PR DESCRIPTION
## Summary
- restrict PR author to `qqrm`
- run PR workflows only when the author is `qqrm`
- limit auto-merge to pull requests from `qqrm`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688b85ad98d08332b7929f8b2e4618ed