### PR TITLE
Add unified CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build and Release CV
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build app
+        run: cargo build --release --manifest-path sitegen/Cargo.toml
+      - name: Validate input files
+        run: cargo run --release --manifest-path sitegen/Cargo.toml -- validate
+      - name: Generate PDFs and HTML
+        run: cargo run --release --manifest-path sitegen/Cargo.toml -- generate
+      - name: Check generated files
+        run: |
+          ls dist/
+          find dist -type f -size 0 -print && exit 1 || true
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build and generate artifacts
+        run: |
+          cargo build --release --manifest-path sitegen/Cargo.toml
+          cargo run --release --manifest-path sitegen/Cargo.toml -- generate
+      - name: Release PDFs
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.pdf
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_dir: ./pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a single workflow building the site, validating sources and generating artifacts
- publish PDFs to a GitHub Release and deploy Pages when main is updated

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688cafb8958483329172cabf21ddb5c3