### PR TITLE
Specify sitegen binary in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Build app
         run: cargo build --release --manifest-path sitegen/Cargo.toml
       - name: Validate input files
-        run: cargo run --release --manifest-path sitegen/Cargo.toml -- validate
+        run: cargo run --release --manifest-path sitegen/Cargo.toml --bin sitegen -- validate
       - name: Generate PDFs and HTML
-        run: cargo run --release --manifest-path sitegen/Cargo.toml -- generate
+        run: cargo run --release --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
       - name: Check generated files
         run: |
           ls dist/
@@ -39,7 +39,7 @@ jobs:
       - name: Build and generate artifacts
         run: |
           cargo build --release --manifest-path sitegen/Cargo.toml
-          cargo run --release --manifest-path sitegen/Cargo.toml -- generate
+          cargo run --release --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
       - name: Release PDFs
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- make workflow run the `sitegen` binary explicitly during validation and generation
- ensure release workflow also invokes the `sitegen` binary

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_689177ab81648332b8b51b21de25c6cd