### PR TITLE
fix: install typst in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin
             sitegen/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('sitegen/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
@@ -23,6 +24,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Install Typst CLI
+        run: cargo install typst-cli --locked
       - name: Build app
         run: cargo build --release --manifest-path sitegen/Cargo.toml
       - name: Run tests


### PR DESCRIPTION
## Summary
- ensure build job installs Typst CLI and caches cargo/bin

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `./bin/act -j build-and-test -W .github/workflows/build.yml` *(fails: no docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_6891ee6f738c83329950a6c73c18559d