### PR TITLE
docs: highlight gh usage and rebase requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@ fails because of network or permission issues, note this in the PR summary.
 
 To replicate CI pipelines locally you can use the `act` tool.
 
-The GitHub CLI (`gh`) is available for interacting with GitHub.
-Always rebase your work onto the latest `main` branch before pushing.
+Tooling notes:
+- The GitHub CLI (`gh`) is available for interacting with GitHub.
+- Always rebase your work onto the latest `main` branch before pushing.
 
 Ensure binary files (for example PDFs) do not appear in the diff and are not added to the repository.
 


### PR DESCRIPTION
## Summary
- emphasize availability of `gh` and reminder to rebase on `main`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

------
https://chatgpt.com/codex/tasks/task_e_6891f03f3a5c8332a843ce288e1cfe93