### PR TITLE
Fix empty file check in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Check generated files
         run: |
           ls dist/
-          find dist -type f -size 0 -print && exit 1 || true
+          if find dist -type f -size 0 -print -quit | grep -q .; then
+            echo "Empty files detected"
+            exit 1
+          fi
 
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- ensure CI checks for empty files in dist before releasing

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6891f50c22608332b3bbcdd2be7c53a9