### PR TITLE
docs: reference typst PDFs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ automatically converted into PDFs and a static website.
 
 - [English CV](./cv.md)
 - [Russian CV](./cv.ru.md)
-- [PDF (en)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf)
-- [PDF (ru)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf)
+- [PDF (en)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
+- [PDF (ru)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
 - [Web version (en)](https://qqrm.github.io/CV/)
 - [Web version (ru)](https://qqrm.github.io/CV/ru/)
 
-Build instructions can be found in the `sitegen` and `latex`/`typst` folders.
+Build instructions can be found in the `sitegen` and `typst` folders.
 
 For the Russian README, see [README_ru.md](./README_ru.md).

--- a/README_ru.md
+++ b/README_ru.md
@@ -6,8 +6,8 @@
 
 - [CV на английском](./cv.md)
 - [Русская версия CV](./cv.ru.md)
-- [PDF на английском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_latex.pdf)
-- [PDF на русском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_latex.pdf)
+- [PDF на английском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
+- [PDF на русском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
 - [Сайт](https://qqrm.github.io/CV/)
 
-Подробности сборки смотрите в каталоге `sitegen` и папках `latex`/`typst`.
+Подробности сборки смотрите в каталогах `sitegen` и `typst`.


### PR DESCRIPTION
## Summary
- update PDF links to typst-generated files
- mention only typst directory in build instructions

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6892135f99fc8332a884d573f06d2541