### PR TITLE
docs: remove latex build references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ automatically converted into PDFs and a static website.
 - [Web version (en)](https://qqrm.github.io/CV/)
 - [Web version (ru)](https://qqrm.github.io/CV/ru/)
 
-Build instructions can be found in the `typst` folder.
+All build instructions are located in the `typst` folder.
 
 For the Russian README, see [README_ru.md](./README_ru.md).

--- a/README_ru.md
+++ b/README_ru.md
@@ -10,4 +10,4 @@
 - [PDF на русском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
 - [Сайт](https://qqrm.github.io/CV/)
 
-Подробности сборки смотрите в каталоге `typst`.
+Все инструкции по сборке находятся в каталоге `typst`.


### PR DESCRIPTION
## Summary
- point README to typst folder for builds
- mention typst-generated PDFs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_689215fe9f088332b45030a1d3d34efc