### PR TITLE
chore: clean pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,14 @@ jobs:
         run: mv sitegen/target/release/sitegen ./sitegen_bin
       - name: Make binary executable
         run: chmod +x sitegen_bin
+      - name: Clean previous site output
+        run: |
+          rm -rf docs
+          rm -rf dist
       - name: Generate site
-        run: ./sitegen_bin
+        run: ./sitegen_bin generate
+      - name: Prepare Pages directory
+        run: mv dist docs
       - uses: ./.github/actions/setup-cv
       - name: Copy README_ru
         run: |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -86,6 +86,7 @@ This repository implements an automated, multilingual, AI-friendly CV generator 
   - Attach all generated PDFs.
   - Explicitly list checksums and direct links.
 - Deploy to GitHub Pages (`/pages`):
+  - Remove any existing published files to ensure a clean deployment.
   - Upload `index.html` and all static assets/json for frontend.
   - Site must be live at `https://<user>.github.io/cv/` and pass a basic availability check.
 
@@ -150,6 +151,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*.pdf
+
+      - name: Clean previous Pages content
+        run: rm -rf pages
 
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
## Summary
- clean Pages workspace before generating site in release workflow
- document Pages cleanup in deployment spec

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68921365bc648332baaa387564f3c89b