### PR TITLE
fix: use PAT for cancel workflow

### DIFF
--- a/.github/workflows/cancel_pr_checks.yml
+++ b/.github/workflows/cancel_pr_checks.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
         with:
+          github-token: ${{ env.ACTIONS_PAT }}
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
@@ -33,6 +34,4 @@ jobs:
                 });
               }
             }
-
-        github-token: ${{ env.ACTIONS_PAT }}
 


### PR DESCRIPTION
## Summary
- ensure cancel workflow uses PAT for GitHub API calls

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `act pull_request -e /tmp/event.json --actor qqrm -s ACTIONS_PAT=ghp_dummy -j cancel -W .github/workflows/cancel_pr_checks.yml` *(fails: Couldn't get a valid docker connection: no DOCKER_HOST and an invalid container socket '')*

------
https://chatgpt.com/codex/tasks/task_e_6892a46523088332b0fd21b40188ba88