### PR TITLE
fix: use PAT for canceling PR checks

### DIFF
--- a/.github/workflows/cancel_pr_checks.yml
+++ b/.github/workflows/cancel_pr_checks.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
         with:
+          github-token: ${{ env.ACTIONS_PAT }}
           script: |
             const pr = context.payload.pull_request;
             const { owner, repo } = context.repo;
@@ -33,6 +34,4 @@ jobs:
                 });
               }
             }
-
-        github-token: ${{ env.ACTIONS_PAT }}
 


### PR DESCRIPTION
## Summary
- ensure `cancel_pr_checks` workflow passes the personal access token to `actions/github-script`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6892a3c0654c8332b46fd771b968de70