### PR TITLE
ci: split release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            sitegen/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('sitegen/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install Typst CLI
+        run: cargo install typst-cli --locked
+      - name: Build app
+        run: cargo build --release --manifest-path sitegen/Cargo.toml
+      - name: Run tests
+        run: cargo test --manifest-path sitegen/Cargo.toml
+      - name: Validate input files
+        run: cargo run --release --manifest-path sitegen/Cargo.toml --bin sitegen -- validate
+      - name: Generate PDFs and HTML
+        run: cargo run --release --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
+      - name: Check generated files
+        run: |
+          ls dist/
+          find dist -type f -size 0 -print && exit 1 || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- add dedicated build workflow without release
- restrict release workflow to manual dispatch only

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(failed: file not found (avatar.jpg))*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(failed: file not found (avatar.jpg))*

------
https://chatgpt.com/codex/tasks/task_e_6892c41fa07c8332853ece6dd51c0ead