### PR TITLE
docs: describe role and language script

### DIFF
--- a/docs/ARCHITECTURE.MD
+++ b/docs/ARCHITECTURE.MD
@@ -5,6 +5,9 @@ This document outlines how the resume is generated and how the CI/CD pipeline op
 ## CV Generation Workflow
 The `sitegen` tool transforms Markdown and Typst sources into HTML pages and PDF files.
 
+### Dynamic role titles and language switching
+Generated HTML pages include a small JavaScript snippet that reads `roles.toml`, injects the role title based on the current URL, and enables language switching.
+
 ![CV generation workflow](diagrams/CV_GENERATION.svg)
 
 ## CI/CD Pipeline


### PR DESCRIPTION
## Summary
- document the runtime script that injects role titles and supports language switching

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: file not found `content/avatar.jpg`)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: file not found `content/avatar.jpg`)*

------
https://chatgpt.com/codex/tasks/task_e_6892c9b729088332a41a84352f2f5a4a