### PR TITLE
Extract date helpers into library and add tests

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -171,12 +171,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "getopts"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -254,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +348,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -384,6 +437,7 @@ dependencies = [
  "pulldown-cmark",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
 ]
 
@@ -402,6 +456,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -468,6 +535,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -666,4 +742,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -11,6 +11,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [[bin]]
 name = "templategen"
 path = "src/templategen.rs"

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -1,0 +1,88 @@
+/// Utilities for site generation.
+///
+/// This module provides helpers for month name parsing and
+/// extracting the start date of the most recent CV entry.
+
+/// Convert an English month name into its number.
+///
+/// Returns `Some(1)` for January through `Some(12)` for December,
+/// or `None` if the name is unknown.
+pub fn month_from_en(name: &str) -> Option<u32> {
+    match name {
+        "January" => Some(1),
+        "February" => Some(2),
+        "March" => Some(3),
+        "April" => Some(4),
+        "May" => Some(5),
+        "June" => Some(6),
+        "July" => Some(7),
+        "August" => Some(8),
+        "September" => Some(9),
+        "October" => Some(10),
+        "November" => Some(11),
+        "December" => Some(12),
+        _ => None,
+    }
+}
+
+/// Convert a Russian month name into its number.
+///
+/// Returns `Some(1)` for "Январь" through `Some(12)` for "Декабрь",
+/// or `None` if the name is unknown.
+pub fn month_from_ru(name: &str) -> Option<u32> {
+    match name {
+        "Январь" => Some(1),
+        "Февраль" => Some(2),
+        "Март" => Some(3),
+        "Апрель" => Some(4),
+        "Май" => Some(5),
+        "Июнь" => Some(6),
+        "Июль" => Some(7),
+        "Август" => Some(8),
+        "Сентябрь" => Some(9),
+        "Октябрь" => Some(10),
+        "Ноябрь" => Some(11),
+        "Декабрь" => Some(12),
+        _ => None,
+    }
+}
+
+/// Read the starting month and year of the most recent CV entry.
+///
+/// The function expects a `cv.md` file in the current directory and
+/// looks for a list item starting with the month and year followed by
+/// an en dash or em dash and the word "Present" (English) or
+/// "Настоящее время" (Russian).
+///
+/// Returns a pair `(year, month)` on success.
+pub fn read_inline_start() -> Option<(i32, u32)> {
+    let content = std::fs::read_to_string("cv.md").ok()?;
+    for line in content.lines() {
+        if let Some((month_str, year_str)) = line
+            .trim()
+            .strip_prefix('*')
+            .and_then(|s| s.split_once('–'))
+            .or_else(|| {
+                line.trim()
+                    .strip_prefix('*')
+                    .and_then(|s| s.split_once('—'))
+            })
+        {
+            let year_str = year_str.trim();
+            if year_str.starts_with("Present") || year_str.starts_with("Настоящее время")
+            {
+                let parts: Vec<&str> = month_str.trim().split_whitespace().collect();
+                if parts.len() == 2 {
+                    let (month_text, year_text) = (parts[0], parts[1]);
+                    let year: i32 = year_text.parse().ok()?;
+                    if let Some(month) =
+                        month_from_en(month_text).or_else(|| month_from_ru(month_text))
+                    {
+                        return Some((year, month));
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -2,6 +2,7 @@ use chrono::{Datelike, NaiveDate, Utc};
 use clap::{Parser, Subcommand};
 use pulldown_cmark::{Options, Parser as CmarkParser, html::push_html};
 use serde::Deserialize;
+use sitegen::read_inline_start;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -20,74 +21,6 @@ enum Commands {
     Validate,
     /// Generate PDFs and HTML into /dist
     Generate,
-}
-
-fn month_from_en(name: &str) -> Option<u32> {
-    match name {
-        "January" => Some(1),
-        "February" => Some(2),
-        "March" => Some(3),
-        "April" => Some(4),
-        "May" => Some(5),
-        "June" => Some(6),
-        "July" => Some(7),
-        "August" => Some(8),
-        "September" => Some(9),
-        "October" => Some(10),
-        "November" => Some(11),
-        "December" => Some(12),
-        _ => None,
-    }
-}
-
-fn month_from_ru(name: &str) -> Option<u32> {
-    match name {
-        "Январь" => Some(1),
-        "Февраль" => Some(2),
-        "Март" => Some(3),
-        "Апрель" => Some(4),
-        "Май" => Some(5),
-        "Июнь" => Some(6),
-        "Июль" => Some(7),
-        "Август" => Some(8),
-        "Сентябрь" => Some(9),
-        "Октябрь" => Some(10),
-        "Ноябрь" => Some(11),
-        "Декабрь" => Some(12),
-        _ => None,
-    }
-}
-
-fn read_inline_start() -> Option<(i32, u32)> {
-    let content = std::fs::read_to_string("cv.md").ok()?;
-    for line in content.lines() {
-        if let Some((month_str, year_str)) = line
-            .trim()
-            .strip_prefix('*')
-            .and_then(|s| s.split_once('–'))
-            .or_else(|| {
-                line.trim()
-                    .strip_prefix('*')
-                    .and_then(|s| s.split_once('—'))
-            })
-        {
-            let year_str = year_str.trim();
-            if year_str.starts_with("Present") || year_str.starts_with("Настоящее время")
-            {
-                let parts: Vec<&str> = month_str.trim().split_whitespace().collect();
-                if parts.len() == 2 {
-                    let (month_text, year_text) = (parts[0], parts[1]);
-                    let year: i32 = year_text.parse().ok()?;
-                    if let Some(month) =
-                        month_from_en(month_text).or_else(|| month_from_ru(month_text))
-                    {
-                        return Some((year, month));
-                    }
-                }
-            }
-        }
-    }
-    None
 }
 
 fn format_duration_en(total_months: i32) -> String {

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -1,0 +1,26 @@
+use sitegen::{month_from_en, month_from_ru, read_inline_start};
+use std::env;
+use std::fs;
+
+#[test]
+fn parses_english_month() {
+    assert_eq!(month_from_en("March"), Some(3));
+    assert_eq!(month_from_en("December"), Some(12));
+}
+
+#[test]
+fn parses_russian_month() {
+    assert_eq!(month_from_ru("Март"), Some(3));
+    assert_eq!(month_from_ru("Декабрь"), Some(12));
+}
+
+#[test]
+fn reads_inline_start_from_markdown() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    fs::write("cv.md", "* March 2024 – Present").unwrap();
+    let result = read_inline_start();
+    env::set_current_dir(original).unwrap();
+    assert_eq!(result, Some((2024, 3)));
+}


### PR DESCRIPTION
## Summary
- centralize month parsing and inline start extraction in new `sitegen` library module
- add integration tests for English/Russian month names and minimal Markdown parsing

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: file not found (searched at /workspace/CV/typst/en/content/avatar.jpg))*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: file not found (searched at /workspace/CV/typst/ru/content/avatar.jpg))*

------
https://chatgpt.com/codex/tasks/task_e_6892c98f23048332a99c0c69a3427920