### PR TITLE
refactor: handle role and locale substitutions in main

### DIFF
--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -14,6 +14,3 @@ clap = { version = "4", features = ["derive"] }
 [dev-dependencies]
 tempfile = "3"
 
-[[bin]]
-name = "templategen"
-path = "src/templategen.rs"


### PR DESCRIPTION
## Summary
- generate locale- and role-specific PDFs directly from `main.rs`
- drop obsolete `templategen` binary from the site generator

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68935fe9e2ec83328b22c82dfcd1dff7