### PR TITLE
refactor: split sitegen binaries

### DIFF
--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -14,3 +14,11 @@ clap = { version = "4", features = ["derive"] }
 [dev-dependencies]
 tempfile = "3"
 
+[[bin]]
+name = "validate"
+path = "src/bin/validate.rs"
+
+[[bin]]
+name = "generate"
+path = "src/bin/generate.rs"
+

--- a/sitegen/src/bin/validate.rs
+++ b/sitegen/src/bin/validate.rs
@@ -1,0 +1,13 @@
+use sitegen::RolesFile;
+use std::error::Error;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    fs::read_to_string("cv.md")?;
+    fs::read_to_string("cv.ru.md")?;
+    let content = fs::read_to_string("roles.toml")?;
+    toml::from_str::<RolesFile>(&content)?;
+    println!("Validation successful");
+    Ok(())
+}
+

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -1,7 +1,12 @@
 /// Utilities for site generation.
 ///
-/// This module provides helpers for month name parsing and
-/// extracting the start date of the most recent CV entry.
+/// This module provides helpers for month name parsing,
+/// extracting the start date of the most recent CV entry,
+/// formatting durations and reading role definitions.
+
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::fs;
 
 /// Convert an English month name into its number.
 ///
@@ -85,4 +90,85 @@ pub fn read_inline_start() -> Option<(i32, u32)> {
         }
     }
     None
+}
+
+/// Format a duration in months into a human readable English string.
+///
+/// The result uses singular and plural forms, e.g. "1 year 2 months".
+pub fn format_duration_en(total_months: i32) -> String {
+    let years = total_months / 12;
+    let months = total_months % 12;
+    let mut parts = Vec::new();
+    if years > 0 {
+        if years == 1 {
+            parts.push("1 year".to_string());
+        } else {
+            parts.push(format!("{} years", years));
+        }
+    }
+    if months > 0 {
+        if months == 1 {
+            parts.push("1 month".to_string());
+        } else {
+            parts.push(format!("{} months", months));
+        }
+    }
+    if parts.is_empty() {
+        "0 months".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+/// Format a duration in months into a human readable Russian string.
+///
+/// The result uses correct declensions, e.g. "1 год 2 месяца".
+pub fn format_duration_ru(total_months: i32) -> String {
+    let years = total_months / 12;
+    let months = total_months % 12;
+    let mut parts = Vec::new();
+    if years > 0 {
+        let year_word = match years {
+            1 => "год",
+            2 | 3 | 4 => "года",
+            _ => "лет",
+        };
+        parts.push(format!("{} {}", years, year_word));
+    }
+    if months > 0 {
+        let month_word = match months {
+            1 => "месяц",
+            2 | 3 | 4 => "месяца",
+            _ => "месяцев",
+        };
+        parts.push(format!("{} {}", months, month_word));
+    }
+    if parts.is_empty() {
+        "0 месяцев".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+#[derive(Deserialize)]
+pub struct RolesFile {
+    /// Mapping from role slug to human readable title.
+    pub roles: BTreeMap<String, String>,
+}
+
+/// Read role definitions from `roles.toml` if present.
+///
+/// Returns a map of role slugs to titles. When the file is missing or
+/// invalid, a small default set is returned instead.
+pub fn read_roles() -> BTreeMap<String, String> {
+    fs::read_to_string("roles.toml")
+        .ok()
+        .and_then(|text| toml::from_str::<RolesFile>(&text).ok())
+        .map(|r| r.roles)
+        .unwrap_or_else(|| {
+            BTreeMap::from([
+                ("tl".to_string(), "Team Lead".to_string()),
+                ("tech".to_string(), "Tech Lead".to_string()),
+            ])
+        })
 }


### PR DESCRIPTION
## Summary
- split `sitegen` into `validate` and `generate` binaries
- expose shared helpers in `sitegen` library
- update Cargo metadata for new binaries and remove subcommand main

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894251962108332866c690cfa716177