### PR TITLE
refactor: use shared resume template

### DIFF
--- a/sitegen/src/main.rs
+++ b/sitegen/src/main.rs
@@ -117,21 +117,7 @@ fn generate() -> Result<(), Box<dyn std::error::Error>> {
     fs::copy("content/avatar.jpg", dist_dir.join("avatar.jpg"))?;
 
     for lang in ["en", "ru"] {
-        Command::new("typst")
-            .args([
-                "compile",
-                "templates/resume.typ",
-                &format!("dist/Belyakov_{lang}_typst.pdf"),
-                "--input",
-                &format!("lang={lang}"),
-                "--input",
-                &format!("role={DEFAULT_ROLE}"),
-                "--root",
-                ".",
-            ])
-            .status()?;
-
-        for (slug, title) in &roles {
+        let compile = |slug: &str, title: &str| -> Result<(), std::io::Error> {
             Command::new("typst")
                 .args([
                     "compile",
@@ -144,7 +130,13 @@ fn generate() -> Result<(), Box<dyn std::error::Error>> {
                     "--root",
                     ".",
                 ])
-                .status()?;
+                .status()
+                .map(|_| ())
+        };
+
+        compile("typst", DEFAULT_ROLE)?;
+        for (slug, title) in &roles {
+            compile(slug, title)?;
         }
     }
     let roles_js = {

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -9,8 +9,8 @@
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
-    #image("../content/avatar.jpg", width: 5cm, height: 5cm)
+    #image("content/avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]
 
-#markdown(file("../cv." + lang + ".md"))
+#markdown(file("cv." + lang + ".md"))


### PR DESCRIPTION
## Summary
- use a single Typst template that pulls the correct markdown file by language
- drive all PDF generation through the shared template

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*
- `typst compile --root . templates/resume.typ dist/Belyakov_en_typst.pdf --input lang=en --input role='Rust Team Lead'` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942378ed0483329c20d846fc0c601a