### PR TITLE
ci: streamline manual PDF workflow

### DIFF
--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -23,7 +23,7 @@ jobs:
       - if: ${{ inputs.builder == 'typst' }}
         uses: ./.github/actions/setup-cv
       - if: ${{ inputs.builder == 'typst' }}
-        name: Prepare release PDFs
+        name: Prepare Typst release PDFs
         run: |
           cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
           cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
@@ -41,24 +41,14 @@ jobs:
         name: Install TypePDF
         run: cargo install typepdf --locked
       - if: ${{ inputs.builder == 'typepdf' }}
-        name: Build English PDF with TypePDF
-        run: typepdf typst/en/Belyakov_en.typ typst/en/Belyakov_en_typepdf.pdf
-      - if: ${{ inputs.builder == 'typepdf' }}
-        name: Build Russian PDF with TypePDF
-        run: typepdf typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_typepdf.pdf
-      - if: ${{ inputs.builder == 'typst' }}
-        name: Upload PDFs
+        name: Build PDFs with TypePDF
+        run: |
+          typepdf typst/en/Belyakov_en.typ typst/en/Belyakov_en_typepdf.pdf
+          typepdf typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_typepdf.pdf
+      - name: Upload PDFs
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: cv-pdfs-typst-${{ env.DATE }}
+          name: cv-pdfs-${{ inputs.builder }}-${{ env.DATE }}
           path: |
-            typst/en/Belyakov_en_typst.pdf
-            typst/ru/Belyakov_ru_typst.pdf
-      - if: ${{ inputs.builder == 'typepdf' }}
-        name: Upload PDFs
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: cv-pdfs-typepdf-${{ env.DATE }}
-          path: |
-            typst/en/Belyakov_en_typepdf.pdf
-            typst/ru/Belyakov_ru_typepdf.pdf
+            typst/en/Belyakov_en_${{ inputs.builder }}.pdf
+            typst/ru/Belyakov_ru_${{ inputs.builder }}.pdf


### PR DESCRIPTION
## Summary
- use a single pdf-manual workflow with a `builder` input choosing Typst or TypePDF
- reuse `setup-cv` for Typst builds and add explicit TypePDF build step
- upload PDFs with a unified artifact step keyed by the selected builder

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf && typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894280f4108833297b805670ff0bc1d