### PR TITLE
chore: separate release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- rename CI workflow to build and remove release job
- ensure manual release workflow remains via workflow_dispatch

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942809c30c833297e363b2b18ccf2f