### PR TITLE
refactor: reuse pdf artifacts in site job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,8 @@ jobs:
         run: mv sitegen/target/release/sitegen ./sitegen_bin
       - name: Make binary executable
         run: chmod +x sitegen_bin
+      - name: Install Typst CLI
+        run: cargo install typst-cli --locked
       - name: Clean previous site output
         run: |
           rm -rf docs
@@ -78,7 +80,6 @@ jobs:
         run: ./sitegen_bin generate
       - name: Prepare Pages directory
         run: mv dist docs
-      - uses: ./.github/actions/setup-cv
       - name: Copy README_ru
         run: |
           cp README_ru.md docs/


### PR DESCRIPTION
## Summary
- run Typst setup and PDF build only in `build_sitegen`
- reuse generated PDFs in `site` job instead of rebuilding

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` (fails: input file not found)
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` (fails: input file not found)


------
https://chatgpt.com/codex/tasks/task_e_68942b77e004833296d8bd7955f91171