### PR TITLE
chore: add workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   pull_request:
 
+concurrency: ci-${{ github.ref }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add concurrency to GitHub Actions CI workflow to auto-cancel stale runs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942b686a248332a386f01af2955a2b