### PR TITLE
refactor Typst template for multilingual resume

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -30,8 +30,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 &format!("lang={lang}"),
                 "--input",
                 &format!("role={DEFAULT_ROLE}"),
-                "--root",
-                ".",
             ])
             .status()?;
 
@@ -45,8 +43,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     &format!("lang={lang}"),
                     "--input",
                     &format!("role={title}"),
-                    "--root",
-                    ".",
                 ])
                 .status()?;
         }

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -9,8 +9,8 @@
 
 #align(center)[
   #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
-    #image("../content/avatar.jpg", width: 5cm, height: 5cm)
+    #image("content/avatar.jpg", width: 5cm, height: 5cm)
   ]
 ]
 
-#markdown(file("../cv." + lang + ".md"))
+#markdown(file("cv." + lang + ".md"))


### PR DESCRIPTION
## Summary
- load language-specific markdown and avatar from root in a single `templates/resume.typ`
- generate PDFs via `typst compile templates/resume.typ dist/Belyakov_{lang}_{role}.pdf --input lang={lang} --input role={title}`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile templates/resume.typ dist/Belyakov_en_typst.pdf --input lang=en --input role="Rust Team Lead"` *(fails: package not found)*
- `typst compile templates/resume.typ dist/Belyakov_ru_typst.pdf --input lang=ru --input role="Rust Team Lead"` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942f2dae088332931c6b588abecb91