### PR TITLE
ci: use concurrency for auto-canceling runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,7 @@ name: ci
 on:
   pull_request:
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+concurrency: ci-${{ github.ref }}
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
- remove unused cancel_pr_checks workflow
- add concurrency group to CI workflow so outdated runs are canceled

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689435de5c40833293818ceaf7d882cd