### PR TITLE
docs: note avatars.mcp usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
 If the Typst CLI is missing, install it with `cargo install typst-cli`. When installation
 fails because of network or permission issues, note this in the PR summary.
 
+Whenever possible, connect to the `avatars.mcp` server to choose a persona suitable for the task, referencing <https://github.com/qqrm/avatars-mcp>. Explicitly mention in each response whether the server was used.
+
 To replicate CI pipelines locally you can use the `act` tool.
 
 Tooling notes:


### PR DESCRIPTION
## Summary
- document need to try connecting to `avatars.mcp` and record usage

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689430aae6488332a81df799bfdf4756