### PR TITLE
ci: cancel outdated runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: ci
 on:
   pull_request:
 
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
 If the Typst CLI is missing, install it with `cargo install typst-cli`. When installation
 fails because of network or permission issues, note this in the PR summary.
 
-Whenever possible, connect to the `avatars.mcp` server to choose a persona suitable for the task, referencing <https://github.com/qqrm/avatars-mcp>. Explicitly mention in each response whether the server was used.
+Whenever possible, connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose a persona suitable for the task (see <https://github.com/qqrm/avatars-mcp> for details). Explicitly mention in each response whether the server was used.
 
 To replicate CI pipelines locally you can use the `act` tool.
 


### PR DESCRIPTION
## Summary
- ensure CI workflow cancels outdated runs via concurrency group
- document avatar MCP usage in contributor instructions

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943b45f990833296b794bd93082e4a