### PR TITLE
Add InlineStartError and handle read_inline_start failures

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -11,7 +11,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
     const DEFAULT_ROLE: &str = "Rust Team Lead";
-    let inline_start = read_inline_start().unwrap_or(INLINE_START);
+    let inline_start = match read_inline_start() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to read inline start: {e}");
+            INLINE_START
+        }
+    };
     let roles = read_roles();
     // Build base PDFs
     let dist_dir = Path::new("dist");
@@ -48,10 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
     let roles_js = {
-        let pairs: Vec<String> = roles
-            .iter()
-            .map(|(k, v)| format!("{k}: '{v}'"))
-            .collect();
+        let pairs: Vec<String> = roles.iter().map(|(k, v)| format!("{k}: '{v}'")).collect();
         format!("{{ {} }}", pairs.join(", "))
     };
     let start_date =
@@ -130,10 +133,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Generate role-specific copies for both languages
     for role in roles.keys() {
-        let pdf_typst_en_role =
-            format!("https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_{}_typst.pdf", role);
-        let pdf_typst_ru_role =
-            format!("https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_{}_typst.pdf", role);
+        let pdf_typst_en_role = format!(
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_{}_typst.pdf",
+            role
+        );
+        let pdf_typst_ru_role = format!(
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_{}_typst.pdf",
+            role
+        );
 
         let en_role_dir = docs_dir.join(role);
         if !en_role_dir.exists() {
@@ -156,4 +163,3 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
-

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -1,4 +1,4 @@
-use sitegen::{month_from_en, month_from_ru, read_inline_start};
+use sitegen::{InlineStartError, month_from_en, month_from_ru, read_inline_start};
 use std::env;
 use std::fs;
 
@@ -20,7 +20,18 @@ fn reads_inline_start_from_markdown() {
     let original = env::current_dir().unwrap();
     env::set_current_dir(dir.path()).unwrap();
     fs::write("cv.md", "* March 2024 – Present").unwrap();
+    let result = read_inline_start().unwrap();
+    env::set_current_dir(original).unwrap();
+    assert_eq!(result, (2024, 3));
+}
+
+#[test]
+fn fails_on_invalid_markdown() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    fs::write("cv.md", "invalid").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
-    assert_eq!(result, Some((2024, 3)));
+    assert!(matches!(result, Err(InlineStartError::Parse)));
 }


### PR DESCRIPTION
## Summary
- define `InlineStartError` to capture file and parse issues
- return `Result` from `read_inline_start` and log problems in `generate`
- test successful and failed inline start parsing

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894469945ac8332a52af941ff6556b6