### PR TITLE
Use lookup tables for month names and expand tests

### DIFF
--- a/sitegen/src/parser.rs
+++ b/sitegen/src/parser.rs
@@ -1,27 +1,48 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
+use std::sync::LazyLock;
+
+static EN_MONTHS: LazyLock<BTreeMap<&'static str, u32>> = LazyLock::new(|| {
+    BTreeMap::from([
+        ("January", 1),
+        ("February", 2),
+        ("March", 3),
+        ("April", 4),
+        ("May", 5),
+        ("June", 6),
+        ("July", 7),
+        ("August", 8),
+        ("September", 9),
+        ("October", 10),
+        ("November", 11),
+        ("December", 12),
+    ])
+});
+
+static RU_MONTHS: LazyLock<BTreeMap<&'static str, u32>> = LazyLock::new(|| {
+    BTreeMap::from([
+        ("Январь", 1),
+        ("Февраль", 2),
+        ("Март", 3),
+        ("Апрель", 4),
+        ("Май", 5),
+        ("Июнь", 6),
+        ("Июль", 7),
+        ("Август", 8),
+        ("Сентябрь", 9),
+        ("Октябрь", 10),
+        ("Ноябрь", 11),
+        ("Декабрь", 12),
+    ])
+});
 
 /// Convert an English month name into its number.
 ///
 /// Returns `Some(1)` for January through `Some(12)` for December,
 /// or `None` if the name is unknown.
 pub fn month_from_en(name: &str) -> Option<u32> {
-    match name {
-        "January" => Some(1),
-        "February" => Some(2),
-        "March" => Some(3),
-        "April" => Some(4),
-        "May" => Some(5),
-        "June" => Some(6),
-        "July" => Some(7),
-        "August" => Some(8),
-        "September" => Some(9),
-        "October" => Some(10),
-        "November" => Some(11),
-        "December" => Some(12),
-        _ => None,
-    }
+    EN_MONTHS.get(name).copied()
 }
 
 /// Convert a Russian month name into its number.
@@ -29,21 +50,7 @@ pub fn month_from_en(name: &str) -> Option<u32> {
 /// Returns `Some(1)` for "Январь" through `Some(12)` for "Декабрь",
 /// or `None` if the name is unknown.
 pub fn month_from_ru(name: &str) -> Option<u32> {
-    match name {
-        "Январь" => Some(1),
-        "Февраль" => Some(2),
-        "Март" => Some(3),
-        "Апрель" => Some(4),
-        "Май" => Some(5),
-        "Июнь" => Some(6),
-        "Июль" => Some(7),
-        "Август" => Some(8),
-        "Сентябрь" => Some(9),
-        "Октябрь" => Some(10),
-        "Ноябрь" => Some(11),
-        "Декабрь" => Some(12),
-        _ => None,
-    }
+    RU_MONTHS.get(name).copied()
 }
 
 /// Read the starting month and year of the most recent CV entry.

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -3,15 +3,45 @@ use std::env;
 use std::fs;
 
 #[test]
-fn parses_english_month() {
-    assert_eq!(month_from_en("March"), Some(3));
-    assert_eq!(month_from_en("December"), Some(12));
+fn parses_english_months() {
+    let months = [
+        ("January", 1),
+        ("February", 2),
+        ("March", 3),
+        ("April", 4),
+        ("May", 5),
+        ("June", 6),
+        ("July", 7),
+        ("August", 8),
+        ("September", 9),
+        ("October", 10),
+        ("November", 11),
+        ("December", 12),
+    ];
+    for (name, number) in months {
+        assert_eq!(month_from_en(name), Some(number));
+    }
 }
 
 #[test]
-fn parses_russian_month() {
-    assert_eq!(month_from_ru("Март"), Some(3));
-    assert_eq!(month_from_ru("Декабрь"), Some(12));
+fn parses_russian_months() {
+    let months = [
+        ("Январь", 1),
+        ("Февраль", 2),
+        ("Март", 3),
+        ("Апрель", 4),
+        ("Май", 5),
+        ("Июнь", 6),
+        ("Июль", 7),
+        ("Август", 8),
+        ("Сентябрь", 9),
+        ("Октябрь", 10),
+        ("Ноябрь", 11),
+        ("Декабрь", 12),
+    ];
+    for (name, number) in months {
+        assert_eq!(month_from_ru(name), Some(number));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace month name match chains with `LazyLock`-backed `BTreeMap` lookups for English and Russian months.
- Add exhaustive tests to ensure all month names resolve correctly.

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944e63bf5c8332b3b374d6392a3212