### PR TITLE
feat: expose inline start error

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -12,7 +12,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
     const DEFAULT_ROLE: &str = "Rust Team Lead";
-    let inline_start = read_inline_start().unwrap_or(INLINE_START);
+    let inline_start = read_inline_start().unwrap_or_else(|e| {
+        eprintln!("Failed to read inline start: {e}");
+        INLINE_START
+    });
     let roles = read_roles();
     // Build base PDFs
     let dist_dir = Path::new("dist");

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -4,5 +4,34 @@
 pub mod parser;
 pub mod renderer;
 
+use std::fmt;
+
+/// Errors that may occur when reading inline CV start information.
+#[derive(Debug)]
+pub enum InlineStartError {
+    /// Failed to read the `cv.md` file.
+    Io(std::io::Error),
+    /// The file did not contain a recognizable inline start entry.
+    InvalidFormat,
+}
+
+impl fmt::Display for InlineStartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InlineStartError::Io(e) => write!(f, "I/O error: {e}"),
+            InlineStartError::InvalidFormat => write!(f, "invalid inline start format"),
+        }
+    }
+}
+
+impl std::error::Error for InlineStartError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            InlineStartError::Io(e) => Some(e),
+            InlineStartError::InvalidFormat => None,
+        }
+    }
+}
+
 pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
 pub use renderer::{format_duration_en, format_duration_ru};

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -1,6 +1,9 @@
-use sitegen::{month_from_en, month_from_ru, read_inline_start};
+use sitegen::{month_from_en, month_from_ru, read_inline_start, InlineStartError};
 use std::env;
 use std::fs;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 #[test]
 fn parses_english_month() {
@@ -16,11 +19,35 @@ fn parses_russian_month() {
 
 #[test]
 fn reads_inline_start_from_markdown() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let dir = tempfile::tempdir().expect("temp dir");
     let original = env::current_dir().unwrap();
     env::set_current_dir(dir.path()).unwrap();
     fs::write("cv.md", "* March 2024 – Present").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
-    assert_eq!(result, Some((2024, 3)));
+    assert_eq!(result.unwrap(), (2024, 3));
+}
+
+#[test]
+fn errors_when_file_missing() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let result = read_inline_start();
+    env::set_current_dir(original).unwrap();
+    assert!(matches!(result, Err(InlineStartError::Io(_))));
+}
+
+#[test]
+fn errors_on_invalid_format() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    fs::write("cv.md", "* March 2024 - ???").unwrap();
+    let result = read_inline_start();
+    env::set_current_dir(original).unwrap();
+    assert!(matches!(result, Err(InlineStartError::InvalidFormat)));
 }


### PR DESCRIPTION
## Summary
- add `InlineStartError` with Display and Error impls
- return `Result` from `read_inline_start`
- log `read_inline_start` failures during generation
- test success and failure paths for inline start parsing

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944e418cac83329040dba81ca7923f