### PR TITLE
chore: harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   pull_request:
 

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -1,5 +1,8 @@
 name: pdf-manual
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -15,6 +18,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Set build date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 
@@ -7,7 +10,8 @@ jobs:
   build_sitegen:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo registry
@@ -60,6 +64,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Download built assets

--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -15,6 +15,12 @@ This document describes how we work with CI/CD and infrastructure in our project
 All automated workflows start with a security step. If the author of a pull
 request is not `qqrm`, the pipeline stops immediately and no jobs run.
 
+### Workflow permissions and secrets
+- Define a `permissions` block in each GitHub Actions workflow.
+- Grant only the scopes required by the jobs (for example, `contents: read` or `actions: write`).
+- Reference sensitive data through GitHub Secrets and avoid hardcoding credentials.
+- Validate and sanitize all external inputs when using `workflow_dispatch` or other triggers.
+
 ## Automatic pull request merging
 - The `.github/workflows/auto_merge.yml` workflow merges pull requests as soon as all checks succeed.
 - Do not remove or disable this workflow. Auto-merge helps keep the main branch healthy.


### PR DESCRIPTION
## Summary
- add explicit permissions to workflows and scope permissions per job
- document workflow permission best practices

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945352b4dc8332a76a02bdad2aafcf