### PR TITLE
docs: capture backlog items from roadmap

### DIFF
--- a/backlog/issues/stale-pages-content.md
+++ b/backlog/issues/stale-pages-content.md
@@ -1,0 +1,14 @@
+# Issue: Stale files served on GitHub Pages
+
+## Description
+The GitHub Pages deployment sometimes retains removed files, causing outdated content such as deleted LaTeX artifacts to remain accessible.
+
+## Steps
+- Investigate the release workflow for missing cleanup steps.
+- Adjust deployment to remove stale files before publishing.
+- Document the updated build and deployment process.
+
+## Acceptance Criteria
+- Deployments rebuild the site on each push to `main` without leftover files.
+- Obsolete files are purged from GitHub Pages during deployment.
+- Documentation reflects the final workflow.

--- a/tasks/backlog/document-new-roles-locales.md
+++ b/tasks/backlog/document-new-roles-locales.md
@@ -1,0 +1,14 @@
+# Task: Document adding new roles or locales
+
+## Description
+Provide clear instructions for contributors on how to introduce a new job role or language variant to the CV system.
+
+## Steps
+- Outline required files and configuration for a new role or locale.
+- Describe commands for generating PDFs and site pages.
+- Include examples for both English and Russian setups.
+
+## Acceptance Criteria
+- Documentation explains how to add a role or language and compile outputs.
+- Examples compile successfully using the documented commands.
+- `cargo test` and Typst builds pass.

--- a/tasks/backlog/role-configurations.md
+++ b/tasks/backlog/role-configurations.md
@@ -1,0 +1,14 @@
+# Task: Add role-based CV configurations
+
+## Description
+Enable generating tailored CV versions for different positions by storing role-specific settings, such as which sections to include and emphasis, in YAML or JSON files.
+
+## Steps
+- Design a configuration schema for roles.
+- Implement parsing of role configuration files.
+- Integrate role settings into the CV generation pipeline.
+
+## Acceptance Criteria
+- Role configuration files exist for each supported position.
+- CV generation uses role settings to include the correct sections.
+- `cargo test` and Typst builds pass.


### PR DESCRIPTION
## Summary
- add tasks for role-based configurations and documenting new roles
- record issue for stale content on GitHub Pages

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945399c8d08332ba161d870b17839a