### PR TITLE
Handle errors while reading inline start

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -12,7 +12,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
     const DEFAULT_ROLE: &str = "Rust Team Lead";
-    let inline_start = read_inline_start().unwrap_or(INLINE_START);
+    let inline_start = match read_inline_start() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to read inline start: {e}");
+            INLINE_START
+        }
+    };
     let roles = read_roles();
     // Build base PDFs
     let dist_dir = Path::new("dist");

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -4,5 +4,31 @@
 pub mod parser;
 pub mod renderer;
 
+use std::{fmt, io};
+
+#[derive(Debug)]
+pub enum InlineStartError {
+    Io(io::Error),
+    Parse,
+}
+
+impl fmt::Display for InlineStartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InlineStartError::Io(_) => write!(f, "failed to read cv.md"),
+            InlineStartError::Parse => write!(f, "could not parse inline start"),
+        }
+    }
+}
+
+impl std::error::Error for InlineStartError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            InlineStartError::Io(err) => Some(err),
+            InlineStartError::Parse => None,
+        }
+    }
+}
+
 pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
 pub use renderer::{format_duration_en, format_duration_ru};

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -1,4 +1,4 @@
-use sitegen::{month_from_en, month_from_ru, read_inline_start};
+use sitegen::{month_from_en, month_from_ru, read_inline_start, InlineStartError};
 use std::env;
 use std::fs;
 
@@ -52,5 +52,27 @@ fn reads_inline_start_from_markdown() {
     fs::write("cv.md", "* March 2024 – Present").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
-    assert_eq!(result, Some((2024, 3)));
+    assert_eq!(result.unwrap(), (2024, 3));
+}
+
+
+#[test]
+fn read_inline_start_returns_error_for_invalid_file() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    fs::write("cv.md", "* Not a valid entry").unwrap();
+    let result = read_inline_start();
+    env::set_current_dir(original).unwrap();
+    assert!(matches!(result, Err(InlineStartError::Parse)));
+}
+
+#[test]
+fn read_inline_start_returns_error_when_file_missing() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let original = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let result = read_inline_start();
+    env::set_current_dir(original).unwrap();
+    assert!(matches!(result, Err(InlineStartError::Io(_))));
 }


### PR DESCRIPTION
## Summary
- add `InlineStartError` and implement `Display`/`Error`
- return `Result` from `read_inline_start`
- log `read_inline_start` failures and extend tests

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689452a319d0833289e239dfccbea3d5