### PR TITLE
refactor: streamline inline start error handling

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -1,5 +1,5 @@
 use chrono::{Datelike, NaiveDate, Utc};
-use log::info;
+use log::{info, warn};
 use pulldown_cmark::{Options, Parser as CmarkParser, html::push_html};
 use sitegen::parser::{read_inline_start, read_roles};
 use sitegen::renderer::{format_duration_en, format_duration_ru};
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let inline_start = match read_inline_start() {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("Failed to read inline start: {e}");
+            warn!("Failed to read inline start: {e}");
             INLINE_START
         }
     };

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -30,5 +30,11 @@ impl std::error::Error for InlineStartError {
     }
 }
 
+impl From<io::Error> for InlineStartError {
+    fn from(err: io::Error) -> Self {
+        InlineStartError::Io(err)
+    }
+}
+
 pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
 pub use renderer::{format_duration_en, format_duration_ru};

--- a/sitegen/src/parser.rs
+++ b/sitegen/src/parser.rs
@@ -63,7 +63,7 @@ pub fn month_from_ru(name: &str) -> Option<u32> {
 ///
 /// Returns a pair `(year, month)` on success.
 pub fn read_inline_start() -> Result<(i32, u32), InlineStartError> {
-    let content = std::fs::read_to_string("cv.md").map_err(InlineStartError::Io)?;
+    let content = std::fs::read_to_string("cv.md")?;
     for line in content.lines() {
         if let Some((month_str, year_str)) = line
             .trim()

--- a/sitegen/tests/lib_tests.rs
+++ b/sitegen/tests/lib_tests.rs
@@ -64,7 +64,9 @@ fn read_inline_start_returns_error_for_invalid_file() {
     fs::write("cv.md", "* Not a valid entry").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
-    assert!(matches!(result, Err(InlineStartError::Parse)));
+    let err = result.expect_err("expected parse error");
+    assert!(matches!(err, InlineStartError::Parse));
+    assert_eq!(err.to_string(), "could not parse inline start");
 }
 
 #[test]
@@ -74,5 +76,7 @@ fn read_inline_start_returns_error_when_file_missing() {
     env::set_current_dir(dir.path()).unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
-    assert!(matches!(result, Err(InlineStartError::Io(_))));
+    let err = result.expect_err("expected io error");
+    assert!(matches!(err, InlineStartError::Io(_)));
+    assert_eq!(err.to_string(), "failed to read cv.md");
 }


### PR DESCRIPTION
## Summary
- simplify inline start parsing by leveraging `?` and `From<io::Error>`
- log warning if inline start parsing fails
- assert error messages in inline start tests

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689464e5555c8332a412cc2cb7493e00