### PR TITLE
refactor: clarify parser and renderer boundaries

### DIFF
--- a/docs/ARCHITECTURE.MD
+++ b/docs/ARCHITECTURE.MD
@@ -9,7 +9,11 @@ The `sitegen` tool transforms Markdown and Typst sources into HTML pages and PDF
 The `sitegen` crate separates responsibilities between two modules:
 
 - `parser` handles input parsing such as month names, inline CV start dates and role definitions.
-- `renderer` formats data for display, including human-readable duration strings.
+  - `month_from_en`/`month_from_ru` convert localized month names to numbers.
+  - `read_inline_start` extracts the latest CV entry start date and reports errors via `InlineStartError`.
+  - `read_roles` loads role titles from `roles.toml`.
+- `renderer` formats data for display.
+  - `format_duration_en` and `format_duration_ru` render human-readable duration strings.
 
 Binary entry points like `generate` and `validate` build on these modules to produce the final artifacts.
 

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -4,31 +4,7 @@
 pub mod parser;
 pub mod renderer;
 
-use std::{fmt, io};
-
-#[derive(Debug)]
-pub enum InlineStartError {
-    Io(io::Error),
-    Parse,
-}
-
-impl fmt::Display for InlineStartError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            InlineStartError::Io(_) => write!(f, "failed to read cv.md"),
-            InlineStartError::Parse => write!(f, "could not parse inline start"),
-        }
-    }
-}
-
-impl std::error::Error for InlineStartError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            InlineStartError::Io(err) => Some(err),
-            InlineStartError::Parse => None,
-        }
-    }
-}
-
-pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
+pub use parser::{
+    InlineStartError, RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles,
+};
 pub use renderer::{format_duration_en, format_duration_ru};


### PR DESCRIPTION
## Summary
- move `InlineStartError` into `parser` module
- document parser/renderer responsibilities in architecture guide

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml -- --test-threads=1`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf && typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*


------
https://chatgpt.com/codex/tasks/task_e_689464d6c2288332999f5a4e3e27fb84