### PR TITLE
feat: validate roles config

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -1,7 +1,7 @@
 use chrono::{Datelike, NaiveDate, Utc};
 use log::info;
 use pulldown_cmark::{Options, Parser as CmarkParser, html::push_html};
-use sitegen::parser::{read_inline_start, read_roles};
+use sitegen::parser::{default_roles, read_inline_start, read_roles};
 use sitegen::renderer::{format_duration_en, format_duration_ru};
 use std::error::Error;
 use std::fs;
@@ -22,7 +22,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             INLINE_START
         }
     };
-    let roles = read_roles();
+    let roles = match read_roles() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to read roles: {e}");
+            default_roles()
+        }
+    };
     // Build base PDFs
     let dist_dir = Path::new("dist");
     if !dist_dir.exists() {

--- a/sitegen/src/bin/validate.rs
+++ b/sitegen/src/bin/validate.rs
@@ -1,5 +1,5 @@
 use log::info;
-use sitegen::parser::RolesFile;
+use sitegen::parser::read_roles;
 use std::error::Error;
 use std::fs;
 
@@ -8,8 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     info!("Starting validation");
     fs::read_to_string("cv.md")?;
     fs::read_to_string("cv.ru.md")?;
-    let content = fs::read_to_string("roles.toml")?;
-    toml::from_str::<RolesFile>(&content)?;
+    read_roles()?;
     info!("Validation successful");
     Ok(())
 }

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -30,5 +30,34 @@ impl std::error::Error for InlineStartError {
     }
 }
 
-pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
+#[derive(Debug)]
+pub enum RolesError {
+    Io(io::Error),
+    Parse(toml::de::Error),
+    EmptyTitle(String),
+}
+
+impl fmt::Display for RolesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RolesError::Io(_) => write!(f, "failed to read roles.toml"),
+            RolesError::Parse(_) => write!(f, "failed to parse roles.toml"),
+            RolesError::EmptyTitle(slug) => write!(f, "role '{slug}' is missing a title"),
+        }
+    }
+}
+
+impl std::error::Error for RolesError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RolesError::Io(err) => Some(err),
+            RolesError::Parse(err) => Some(err),
+            RolesError::EmptyTitle(_) => None,
+        }
+    }
+}
+
+pub use parser::{
+    RolesFile, default_roles, month_from_en, month_from_ru, read_inline_start, read_roles,
+};
 pub use renderer::{format_duration_en, format_duration_ru};


### PR DESCRIPTION
## Summary
- add default role mappings and validate roles.toml contents
- provide detailed errors for invalid roles
- cover role parser with tests

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689464cb41f88332bdd456297dcd0060