### PR TITLE
Clarify avatar requirement in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
 If the Typst CLI is missing, install it with `cargo install typst-cli`. When installation
 fails because of network or permission issues, note this in the PR summary.
 
-Whenever possible, connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose a persona suitable for the task (see <https://github.com/qqrm/avatars-mcp> for details). Explicitly mention in each response whether the server was used.
+Always connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose an avatar persona for each task (see <https://github.com/qqrm/avatars-mcp> for details). In the PR description, state which avatar was selected and briefly why. If the server is unreachable, note this in the PR.
 
 To replicate CI pipelines locally you can use the `act` tool.
 


### PR DESCRIPTION
## Summary
- Require selecting an avatar persona from `avatars.mcp` for each task and reporting the choice in PR descriptions

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

Avatar used: **Business Analyst** – chosen to focus on clear requirements and documentation.


------
https://chatgpt.com/codex/tasks/task_e_6894a3d39ac8833284b8ad3f25ca5293