### PR TITLE
Add Typst resume sources

### DIFF
--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -33,6 +33,13 @@ To compile PDFs locally, install the Typst CLI:
 cargo install typst-cli
 ```
 
+Once installed, the resumes can be built with:
+
+```bash
+typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
+typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
+```
+
 ### Local pipeline runs
 CI workflows are defined in GitHub Actions. Use the [`act`](https://github.com/nektos/act) tool to execute them locally.
 

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -1,16 +1,18 @@
-#import "@preview/markdown:0.3.1": markdown
-#let lang = context().input("lang", "en")
-#let role = context().input("role", "Rust Team Lead")
-#let name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
+// Resume template rendered through the `resume` function.
 
-#align(center)[= {name}]
-#align(center)[*{role}*]
-#align(center)[#datetime.today().display()]
+#let resume(lang: "en", role: "Rust Team Lead") = [
+  #let name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
 
-#align(center)[
-  #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
-    #image("content/avatar.jpg", width: 5cm, height: 5cm)
+  #align(center)[= {name}]
+  #align(center)[*{role}*]
+  #align(center)[#datetime.today().display()]
+
+  #align(center)[
+    #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true)[
+      #image("../content/avatar.jpg", width: 5cm, height: 5cm)
+    ]
   ]
-]
 
-#markdown(file("cv." + lang + ".md"))
+  #let cv_path = if lang == "ru" { "../cv.ru.md" } else { "../cv.md" }
+  #raw(read(cv_path))
+]

--- a/typst.toml
+++ b/typst.toml
@@ -1,0 +1,2 @@
+[package]
+name = "cv"

--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,0 +1,2 @@
+#import "../../templates/resume.typ": resume
+#resume(lang: "en", role: "Rust Team Lead")

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,0 +1,2 @@
+#import "../../templates/resume.typ": resume
+#resume(lang: "ru", role: "Руководитель команды Rust")


### PR DESCRIPTION
## Summary
- add Typst driver files for English and Russian resumes
- create reusable resume template that loads existing markdown and assets
- document local Typst build commands

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_689464cebb348332a388fc74e08e13ed