### PR TITLE
docs: clarify user-requested rebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Tooling notes:
   3. `git checkout <your-branch>`
   4. `git rebase origin/main`
 
+- When the user explicitly requests a rebase, update `main` to the latest state and reapply the task solution from scratch.
+
 Ensure binary files (for example PDFs) do not appear in the diff and are not added to the repository.
 
 When analyzing incoming tasks, apply the following roles:


### PR DESCRIPTION
## Summary
- document that when a user requests a rebase, `main` should be updated and the task solution reapplied from scratch

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- analyst – chosen to focus on refining project documentation

------
https://chatgpt.com/codex/tasks/task_e_6894a91d8db88332b4129cf658562e6a