### PR TITLE
refactor: isolate parser error

### DIFF
--- a/docs/ARCHITECTURE.MD
+++ b/docs/ARCHITECTURE.MD
@@ -8,10 +8,10 @@ The `sitegen` tool transforms Markdown and Typst sources into HTML pages and PDF
 ### Module structure
 The `sitegen` crate separates responsibilities between two modules:
 
-- `parser` handles input parsing such as month names, inline CV start dates and role definitions.
-- `renderer` formats data for display, including human-readable duration strings.
+- `parser` converts raw files into structured data. It exposes helpers such as `month_from_en`, `month_from_ru`, `read_inline_start`, `read_roles`, and the `InlineStartError` type.
+- `renderer` produces template-friendly strings, for example `format_duration_en` and `format_duration_ru`.
 
-Binary entry points like `generate` and `validate` build on these modules to produce the final artifacts.
+These modules are independent and are re-exported by the crate root so the binaries can rely on a concise API without cross-module coupling. Binary entry points like `generate` and `validate` build on these modules to produce the final artifacts.
 
 ### Dynamic role titles and language switching
 Generated HTML pages include a small JavaScript snippet that reads `roles.toml`, injects the role title based on the current URL, and enables language switching.

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -3,38 +3,12 @@
 /// This crate exposes modules for data parsing and template rendering.
 pub mod parser;
 pub mod renderer;
-
-use std::{fmt, io};
-
-#[derive(Debug)]
-pub enum InlineStartError {
-    Io(io::Error),
-    Parse,
-}
-
-impl fmt::Display for InlineStartError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            InlineStartError::Io(_) => write!(f, "failed to read cv.md"),
-            InlineStartError::Parse => write!(f, "could not parse inline start"),
-        }
-    }
-}
-
-impl std::error::Error for InlineStartError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            InlineStartError::Io(err) => Some(err),
-            InlineStartError::Parse => None,
-        }
-    }
-}
-
-impl From<io::Error> for InlineStartError {
-    fn from(err: io::Error) -> Self {
-        InlineStartError::Io(err)
-    }
-}
-
-pub use parser::{RolesFile, month_from_en, month_from_ru, read_inline_start, read_roles};
+pub use parser::{
+    InlineStartError,
+    RolesFile,
+    month_from_en,
+    month_from_ru,
+    read_inline_start,
+    read_roles,
+};
 pub use renderer::{format_duration_en, format_duration_ru};

--- a/sitegen/src/parser.rs
+++ b/sitegen/src/parser.rs
@@ -1,8 +1,39 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
-use crate::InlineStartError;
+use std::fmt;
+use std::io;
 use phf::phf_map;
+
+#[derive(Debug)]
+pub enum InlineStartError {
+    Io(io::Error),
+    Parse,
+}
+
+impl fmt::Display for InlineStartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InlineStartError::Io(_) => write!(f, "failed to read cv.md"),
+            InlineStartError::Parse => write!(f, "could not parse inline start"),
+        }
+    }
+}
+
+impl std::error::Error for InlineStartError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            InlineStartError::Io(err) => Some(err),
+            InlineStartError::Parse => None,
+        }
+    }
+}
+
+impl From<io::Error> for InlineStartError {
+    fn from(err: io::Error) -> Self {
+        InlineStartError::Io(err)
+    }
+}
 
 static EN_MONTHS: phf::Map<&'static str, u32> = phf_map! {
     "January" => 1,


### PR DESCRIPTION
## Summary
- move `InlineStartError` into `parser` module and re-export parsing helpers
- document parser vs renderer boundaries in architecture notes

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Tester — selected to focus on validating parser and renderer behavior through tests.

------
https://chatgpt.com/codex/tasks/task_e_6894e2b5b8a88332ae7872a238c544c0