### PR TITLE
Validate and enrich roles configuration parsing

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             INLINE_START
         }
     };
-    let roles = read_roles();
+    let roles = read_roles().expect("failed to read roles");
     // Build base PDFs
     let dist_dir = Path::new("dist");
     if !dist_dir.exists() {

--- a/sitegen/src/bin/validate.rs
+++ b/sitegen/src/bin/validate.rs
@@ -1,5 +1,5 @@
 use log::info;
-use sitegen::parser::RolesFile;
+use sitegen::parser::read_roles;
 use std::error::Error;
 use std::fs;
 
@@ -8,8 +8,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     info!("Starting validation");
     fs::read_to_string("cv.md")?;
     fs::read_to_string("cv.ru.md")?;
-    let content = fs::read_to_string("roles.toml")?;
-    toml::from_str::<RolesFile>(&content)?;
+    fs::read_to_string("roles.toml")?;
+    read_roles()?;
     info!("Validation successful");
     Ok(())
 }

--- a/sitegen/src/lib.rs
+++ b/sitegen/src/lib.rs
@@ -6,6 +6,7 @@ pub mod renderer;
 pub use parser::{
     InlineStartError,
     RolesFile,
+    RolesError,
     month_from_en,
     month_from_ru,
     read_inline_start,


### PR DESCRIPTION
## Summary
- add `RolesError` with validation for empty titles and parse/IO failures
- merge `roles.toml` entries with defaults and surface descriptive errors
- extend unit tests for default roles, invalid files, and empty titles

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Developer Avatar – Focused on code quality and automation for Rust projects.

------
https://chatgpt.com/codex/tasks/task_e_6894e6a4c4bc8332bbabfc1a313719ec