### PR TITLE
docs: update typst paths and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ automatically converted into PDFs and a static website.
 - [Web version (en)](https://qqrm.github.io/CV/)
 - [Web version (ru)](https://qqrm.github.io/CV/ru/)
 
-All build instructions are located in the `typst` folder.
+The Typst resume template lives in the `templates` directory.
+Install the Typst CLI and generate a PDF:
+
+```bash
+cargo install typst-cli
+typst compile templates/resume.typ resume.pdf
+```
 
 For the Russian README, see [README_ru.md](./README_ru.md).

--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -27,6 +27,12 @@ To compile PDFs locally, install the Typst CLI:
 cargo install typst-cli
 ```
 
+Then generate the resume PDF:
+
+```bash
+typst compile templates/resume.typ resume.pdf
+```
+
 ### Local pipeline runs
 CI workflows are defined in GitHub Actions. To execute them locally you can install
 the [`act`](https://github.com/nektos/act) tool and run `act` from the repository root.


### PR DESCRIPTION
## Summary
- fix README to point to templates directory and show typst build example
- add resume compile step to DevOps guide
- document typst-cli installation in README

## Testing
- `cargo install typst-cli`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile templates/resume.typ /tmp/resume.pdf` *(fails: package not found for @preview/markdown:0.3.1)*
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945394eaa0833284172463a3c6a79a