### PR TITLE
chore: drop local makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,21 +2,7 @@ All documentation in this repository is maintained in English. Source code comme
 
 README files are usually edited manually. Do not change `README.md` or `README_ru.md` unless the task explicitly requires it.
 
-Before committing, run the tests:
-
-```
-cargo test --manifest-path sitegen/Cargo.toml
-```
-
-Also verify local PDF builds with Typst:
-
-```
-typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
-typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
-```
-
-If the Typst CLI is missing, install it with `cargo install typst-cli`. When installation
-fails because of network or permission issues, note this in the PR summary.
+This project runs exclusively in GitHub CI. Local build scripts such as Makefiles are intentionally avoided. If you need to run checks locally, mirror the commands defined in `.github/workflows/ci.yml`.
 
 Whenever possible, connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose a persona suitable for the task (see <https://github.com/qqrm/avatars-mcp> for details). Explicitly mention in each response whether the server was used.
 

--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -33,6 +33,8 @@ To compile PDFs locally, install the Typst CLI:
 cargo install typst-cli
 ```
 
+Builds, tests, and Typst compilation run in GitHub CI. No local Makefile is provided.
+
 ### Local pipeline runs
 CI workflows are defined in GitHub Actions. Use the [`act`](https://github.com/nektos/act) tool to execute them locally.
 

--- a/tools/ENVIRONMENT.md
+++ b/tools/ENVIRONMENT.md
@@ -28,3 +28,6 @@ This toolset is provided as standard for every new team member.
 ```bash
 cargo install cargo-make cargo-watch cargo-edit cargo-nextest cargo-audit proptest cargo-fuzz cargo-tarpaulin mdbook zola svgbob gitui delta helix fd bat ripgrep
 ```
+
+
+Builds and tests run exclusively in GitHub CI; no local Makefile is provided.


### PR DESCRIPTION
## Summary
- remove local Makefile and references
- CI workflow runs cargo and typst commands directly
- clarify in docs and agent guidelines that project is GitHub CI-only

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(fails: input file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946439a25883328f448f3a3c1f1791