### PR TITLE
feat(sitegen): add logging and docs

### DIFF
--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -84,7 +84,14 @@ act pull_request -n
 RUST_LOG=info cargo run --bin generate
 ```
 
-Use `debug` for more verbose messages or `warn` to reduce noise.
+Use module filters for finer control:
+
+```bash
+RUST_LOG=sitegen=debug cargo run --bin generate
+```
+
+Replace `debug` with `warn` to reduce noise or with `trace` for
+maximum verbosity.
 
 ## Avatars directory
 Role descriptions in Markdown format are stored in the `avatars/` folder at the repository root. Each file describes a typical project role and can be reused in documentation or onboarding materials.

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -22,7 +22,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             INLINE_START
         }
     };
+    info!("Using inline start: {}-{}", inline_start.0, inline_start.1);
     let roles = read_roles().expect("failed to read roles");
+    info!("Loaded {} roles", roles.len());
     // Build base PDFs
     let dist_dir = Path::new("dist");
     if !dist_dir.exists() {


### PR DESCRIPTION
## Summary
- integrate env_logger messages during site generation
- document how to enable and filter logs via `RUST_LOG`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Tester — highlighting the value of thorough validation when adding logging.


------
https://chatgpt.com/codex/tasks/task_e_68952b17cec083329471c18302394a2e