### PR TITLE
feat: improve logging and usage docs

### DIFF
--- a/docs/DevOps_Guide.md
+++ b/docs/DevOps_Guide.md
@@ -78,13 +78,15 @@ act pull_request -n
 
 ## Enabling Logs
 `sitegen` binaries use [`env_logger`](https://docs.rs/env_logger/) for logging. Set the
-`RUST_LOG` environment variable to control log output:
+`RUST_LOG` environment variable to control verbosity:
 
 ```bash
 RUST_LOG=info cargo run --bin generate
+RUST_LOG=debug cargo run --bin validate
 ```
 
-Use `debug` for more verbose messages or `warn` to reduce noise.
+The default level is `warn`. Increase to `debug` for more details or
+lower to `error` to reduce noise.
 
 ## Avatars directory
 Role descriptions in Markdown format are stored in the `avatars/` folder at the repository root. Each file describes a typical project role and can be reused in documentation or onboarding materials.


### PR DESCRIPTION
## Summary
- log parser activity for inline start and role loading
- document enabling `sitegen` logs via `RUST_LOG`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Developer Avatar — suited for enhancing Rust tooling and logging.

------
https://chatgpt.com/codex/tasks/task_e_68952ebec7d883328b217fcb86c4caff