### PR TITLE
Make default role optional in site generation

### DIFF
--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -9,7 +9,7 @@
 <body>
 <header>
     <h1>Alexey Belyakov</h1>
-    <p><strong id='position'>Rust Team Lead</strong></p>
+    
     <p>DATE</p>
 </header>
 <div class='content'>
@@ -181,7 +181,8 @@
 <script>
     const positions = { em: 'Engineering Manager', hod: 'Head of Development', tech: 'Tech Lead', tl: 'Team Lead' };
     const seg = window.location.pathname.split('/').filter(Boolean).pop();
-    if (positions[seg]) { document.getElementById('position').textContent = positions[seg]; }
+    const position = document.getElementById('position');
+    if (position && positions[seg]) { position.textContent = positions[seg]; }
 </script>
 </body>
 </html>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -9,7 +9,7 @@
 <body>
 <header>
     <h1>Алексей Беляков</h1>
-    <p><strong id='position'>Rust Team Lead</strong></p>
+    
     <p>DATE</p>
 </header>
 <div class='content'>
@@ -171,7 +171,8 @@
 <script>
     const positions = { em: 'Engineering Manager', hod: 'Head of Development', tech: 'Tech Lead', tl: 'Team Lead' };
     const seg = window.location.pathname.split('/').filter(Boolean).pop();
-    if (positions[seg]) { document.getElementById('position').textContent = positions[seg]; }
+    const position = document.getElementById('position');
+    if (position && positions[seg]) { position.textContent = positions[seg]; }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow generating PDFs and pages without a default role
- update HTML templates and fixtures for missing role support

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf && typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Tester – focused on validating outputs and behavior.

------
https://chatgpt.com/codex/tasks/task_e_68952efa5af48332af1baccb7e61f81c