### PR TITLE
Make role line optional in resume template

### DIFF
--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -1,10 +1,10 @@
 // Resume template rendered through the `resume` function.
 
-#let resume(lang: "en", role: "Rust Team Lead") = [
+#let resume(lang: "en", role: "") = [
   #let name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
 
   #align(center)[= {name}]
-  #align(center)[*{role}*]
+  #if role != "" [#align(center)[*{role}*]]
   #align(center)[#datetime.today().display()]
 
   #align(center)[

--- a/typst/en/Belyakov_en.typ
+++ b/typst/en/Belyakov_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Rust Team Lead")
+#resume(lang: "en")

--- a/typst/ru/Belyakov_ru.typ
+++ b/typst/ru/Belyakov_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Руководитель команды Rust")
+#resume(lang: "ru")


### PR DESCRIPTION
## Summary
- show the resume role only when provided
- default to no role in Belyakov resume sources

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: developer – emphasizes Rust development and code quality.

------
https://chatgpt.com/codex/tasks/task_e_6895353e5f7483328e27f0d371711333