### PR TITLE
docs: note avatar usage in responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
 If the Typst CLI is missing, install it with `cargo install typst-cli`. When installation
 fails because of network or permission issues, note this in the PR summary.
 
-Always connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose an avatar persona for each task (see <https://github.com/qqrm/avatars-mcp> for details). In the PR description, state which avatar was selected and briefly why. If the server is unreachable, note this in the PR.
+Always connect to the `avatars.mcp` server at <https://qqrm.github.io/avatars-mcp/> to choose an avatar persona for each task (see <https://github.com/qqrm/avatars-mcp> for details). In your final response for each task and in the PR description, state which avatar was selected and briefly why; if no avatar is used, explicitly note this. If the server is unreachable, mention this in the PR.
 
 To replicate CI pipelines locally you can use the `act` tool.
 


### PR DESCRIPTION
## Summary
- document that contributors must state which avatar was used in each task response and PR description

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` (fails: failed to load file (access denied))
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` (fails: failed to load file (access denied))

## Avatar
R DevOps

------
https://chatgpt.com/codex/tasks/task_e_689537d88bd483329ea75a4cb67087ba