### PR TITLE
test: check EM role PDF links

### DIFF
--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -51,5 +51,17 @@ fn generates_expected_dist() {
     assert_eq!(index_normalized, index_expected);
     assert_eq!(index_ru_normalized, index_ru_expected);
 
+    // Ensure role-specific pages link to the correct PDFs
+    let em_page = fs::read_to_string(dist.join("em").join("index.html")).expect("read em/index.html");
+    assert!(
+        em_page.contains("Belyakov_en_em_typst.pdf"),
+        "missing English EM PDF link"
+    );
+    let em_ru_page = fs::read_to_string(dist.join("ru").join("em").join("index.html")).expect("read ru/em/index.html");
+    assert!(
+        em_ru_page.contains("Belyakov_ru_em_typst.pdf"),
+        "missing Russian EM PDF link"
+    );
+
     fs::remove_dir_all(&dist).expect("failed to remove dist");
 }


### PR DESCRIPTION
## Summary
- add regression checks that EM pages link to the correct PDFs

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: Tester – chosen for its focus on validating software through thorough testing.

------
https://chatgpt.com/codex/tasks/task_e_6895462df3d083328eb4453d702ad6be