### PR TITLE
ci: use setup-cv action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            sitegen/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('sitegen/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-      - name: Cache Typst
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/typst
-          key: ${{ runner.os }}-typst-${{ hashFiles('typst/**/*.typ') }}
-          restore-keys: ${{ runner.os }}-typst-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Install Typst CLI
-        run: cargo install typst-cli --locked
+      - uses: ./.github/actions/setup-cv
       - name: Cargo build
         run: cargo build --manifest-path sitegen/Cargo.toml
       - name: Cargo test
@@ -48,12 +27,6 @@ jobs:
         run: |
           test -s dist/index.html
           test -s dist/ru/index.html
-      - name: Build Typst PDFs
-        run: |
-          set -e
-          for file in typst/**/*.typ; do
-            typst compile "$file" "${file%.typ}.pdf"
-          done
       - name: Upload Typst PDFs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- streamline CI by using local setup-cv composite action instead of explicit cargo/typst setup and pdf compilation steps
- retain build, test, and typst artifact upload after action

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: DevOps CI Maintainer avatar was selected for focusing on CI pipeline maintenance.

------
https://chatgpt.com/codex/tasks/task_e_689552fe640c8332bed1eec8870021fd