### PR TITLE
test: cover duration formatting

### DIFF
--- a/sitegen/src/renderer.rs
+++ b/sitegen/src/renderer.rs
@@ -55,3 +55,29 @@ pub fn format_duration_ru(total_months: i32) -> String {
         parts.join(" ")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_duration_en() {
+        assert_eq!(format_duration_en(0), "0 months");
+        assert_eq!(format_duration_en(1), "1 month");
+        assert_eq!(format_duration_en(2), "2 months");
+        assert_eq!(format_duration_en(12), "1 year");
+        assert_eq!(format_duration_en(24), "2 years");
+        assert_eq!(format_duration_en(14), "1 year 2 months");
+    }
+
+    #[test]
+    fn test_format_duration_ru() {
+        assert_eq!(format_duration_ru(0), "0 месяцев");
+        assert_eq!(format_duration_ru(1), "1 месяц");
+        assert_eq!(format_duration_ru(2), "2 месяца");
+        assert_eq!(format_duration_ru(5), "5 месяцев");
+        assert_eq!(format_duration_ru(12), "1 год");
+        assert_eq!(format_duration_ru(24), "2 года");
+        assert_eq!(format_duration_ru(60), "5 лет");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for English and Russian duration formatting

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Tester avatar from https://qqrm.github.io/avatars-mcp/ was used for its focus on designing and executing test cases.

------
https://chatgpt.com/codex/tasks/task_e_689552f79f7083329314a7eae191171b