### PR TITLE
refactor: unify html generation

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "env_filter"
@@ -256,6 +294,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +322,20 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "handlebars"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -321,6 +383,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
@@ -432,6 +500,50 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
 ]
 
 [[package]]
@@ -612,6 +724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scc"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +771,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +817,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +845,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "env_logger",
+ "handlebars",
  "log",
  "phf",
  "pulldown-cmark",
@@ -751,6 +893,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +974,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +1008,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
 phf = { version = "0.11", features = ["macros"] }
+handlebars = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -1,6 +1,8 @@
 use chrono::{Datelike, NaiveDate, Utc};
+use handlebars::Handlebars;
 use log::{info, warn};
-use pulldown_cmark::{html::push_html, Options, Parser as CmarkParser};
+use pulldown_cmark::{Options, Parser as CmarkParser, html::push_html};
+use serde::Serialize;
 use sitegen::parser::{read_inline_start, read_roles};
 use sitegen::renderer::{format_duration_en, format_duration_ru};
 use std::error::Error;
@@ -8,11 +10,31 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+#[derive(Serialize)]
+struct TemplateData<'a> {
+    lang: &'a str,
+    title: &'a str,
+    name: &'a str,
+    prefix: &'a str,
+    position_block: &'a str,
+    date_str: &'a str,
+    avatar_src: &'a str,
+    html_body: &'a str,
+    pdf_typst_en: &'a str,
+    pdf_typst_ru: &'a str,
+    roles_js: &'a str,
+    link_to_en: Option<&'a str>,
+}
+
+fn render_page(data: &TemplateData) -> Result<String, handlebars::RenderError> {
+    let hb = Handlebars::new();
+    let tmpl = include_str!("../../templates/page.hbs");
+    hb.render_template(tmpl, data)
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     info!("Starting site generation");
-    const AVATAR_SRC_EN: &str = "avatar.jpg";
-    const AVATAR_SRC_RU: &str = "../avatar.jpg";
     const INLINE_START: (i32, u32) = (2024, 3);
     const DEFAULT_ROLE: &str = "";
     let inline_start = match read_inline_start() {
@@ -78,65 +100,23 @@ fn main() -> Result<(), Box<dyn Error>> {
     } else {
         format!("<p><strong id='position'>{DEFAULT_ROLE}</strong></p>")
     };
-    // Generate English version
+    // Prepare HTML bodies
     let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf";
     let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf";
 
     let markdown_input = fs::read_to_string("cv.md")?;
     let parser = CmarkParser::new_ext(&markdown_input, Options::all());
-    let mut html_body = String::new();
-    push_html(&mut html_body, parser);
-    html_body = html_body.replace("./cv.ru.md", "ru/");
-    html_body = html_body.replace(
+    let mut html_body_en = String::new();
+    push_html(&mut html_body_en, parser);
+    html_body_en = html_body_en.replace("./cv.ru.md", "ru/");
+    html_body_en = html_body_en.replace(
         "March 2024 – Present  (1 year)",
         &format!("March 2024 – Present  ({})", duration_en),
     );
-    if let Some(end) = html_body.find("</h1>") {
-        html_body = html_body[end + 5..].trim_start().to_string();
+    if let Some(end) = html_body_en.find("</h1>") {
+        html_body_en = html_body_en[end + 5..].trim_start().to_string();
     }
 
-    let html_template = format!(
-        "<!DOCTYPE html>
-<html lang='en'>
-<head>
-    <meta charset='UTF-8'>
-    <title>Alexey Belyakov - CV</title>
-    <link rel='icon' href='favicon.svg' type='image/svg+xml'>
-    <link rel='stylesheet' href='style.css'>
-</head>
-<body>
-<header>
-    <h1>Alexey Belyakov</h1>
-    {position_block}
-    <p>{date_str}</p>
-</header>
-<div class='content'>
-<img class='avatar' src='{avatar_src}' alt='Avatar'>
-{html_body}
-</div>
-<footer>
-    <p><a href='{pdf_typst_en}'>Download PDF (EN)</a></p>
-    <p><a href='{pdf_typst_ru}'>Скачать PDF (RU)</a></p>
-</footer>
-<script>
-    const positions = {roles_js};
-    const seg = window.location.pathname.split('/').filter(Boolean).pop();
-    const position = document.getElementById('position');
-    if (position && positions[seg]) {{ position.textContent = positions[seg]; }}
-</script>
-</body>
-</html>
-",
-        position_block = position_block,
-        date_str = date_str,
-        avatar_src = AVATAR_SRC_EN,
-        html_body = html_body,
-        pdf_typst_en = pdf_typst_en,
-        pdf_typst_ru = pdf_typst_ru,
-        roles_js = roles_js,
-    );
-
-    // Generate Russian version
     let markdown_ru = fs::read_to_string("cv.ru.md")?;
     let parser_ru = CmarkParser::new_ext(&markdown_ru, Options::all());
     let mut html_body_ru = String::new();
@@ -149,47 +129,36 @@ fn main() -> Result<(), Box<dyn Error>> {
         html_body_ru = html_body_ru[end + 5..].trim_start().to_string();
     }
 
-    let html_template_ru = format!(
-        "<!DOCTYPE html>
-<html lang='ru'>
-<head>
-    <meta charset='UTF-8'>
-    <title>Алексей Беляков - Резюме</title>
-    <link rel='icon' href='../favicon.svg' type='image/svg+xml'>
-    <link rel='stylesheet' href='../style.css'>
-</head>
-<body>
-<header>
-    <h1>Алексей Беляков</h1>
-    {position_block}
-    <p>{date_str}</p>
-</header>
-<div class='content'>
-<img class='avatar' src='{avatar_src}' alt='Avatar'>
-<p><em><a href='../'>Ссылка на английскую версию</a></em></p>
-{html_body}
-</div>
-<footer>
-    <p><a href='{pdf_typst_en}'>Download PDF (EN)</a></p>
-    <p><a href='{pdf_typst_ru}'>Скачать PDF (RU)</a></p>
-</footer>
-<script>
-    const positions = {roles_js};
-    const seg = window.location.pathname.split('/').filter(Boolean).pop();
-    const position = document.getElementById('position');
-    if (position && positions[seg]) {{ position.textContent = positions[seg]; }}
-</script>
-</body>
-</html>
-",
-        position_block = position_block,
-        date_str = date_str,
-        avatar_src = AVATAR_SRC_RU,
-        html_body = html_body_ru,
-        pdf_typst_en = pdf_typst_en,
-        pdf_typst_ru = pdf_typst_ru,
-        roles_js = roles_js,
-    );
+    // Render base pages
+    let html_template = render_page(&TemplateData {
+        lang: "en",
+        title: "Alexey Belyakov - CV",
+        name: "Alexey Belyakov",
+        prefix: "",
+        position_block: &position_block,
+        date_str: &date_str,
+        avatar_src: "avatar.jpg",
+        html_body: &html_body_en,
+        pdf_typst_en,
+        pdf_typst_ru,
+        roles_js: &roles_js,
+        link_to_en: None,
+    })?;
+
+    let html_template_ru = render_page(&TemplateData {
+        lang: "ru",
+        title: "Алексей Беляков - Резюме",
+        name: "Алексей Беляков",
+        prefix: "../",
+        position_block: &position_block,
+        date_str: &date_str,
+        avatar_src: "../avatar.jpg",
+        html_body: &html_body_ru,
+        pdf_typst_en,
+        pdf_typst_ru,
+        roles_js: &roles_js,
+        link_to_en: Some("../"),
+    })?;
 
     let docs_dir = Path::new("dist");
     if !docs_dir.exists() {
@@ -226,46 +195,52 @@ fn main() -> Result<(), Box<dyn Error>> {
         if !en_role_dir.exists() {
             fs::create_dir_all(&en_role_dir)?;
         }
-        let base_en = if DEFAULT_ROLE.is_empty() {
-            html_template.replacen(
-                "<h1>Alexey Belyakov</h1>\n    \n",
-                "<h1>Alexey Belyakov</h1>\n    <p><strong id='position'></strong></p>\n    ",
-                1,
-            )
+        let position_block_role = if DEFAULT_ROLE.is_empty() {
+            "<p><strong id='position'></strong></p>"
         } else {
-            html_template.clone()
+            &position_block
         };
-        let role_template_en = base_en
-            .replace(pdf_typst_en, &pdf_typst_en_role)
-            .replace(pdf_typst_ru, &pdf_typst_ru_role);
-        fs::write(en_role_dir.join("index.html"), role_template_en)?;
+        let en_role_html = render_page(&TemplateData {
+            lang: "en",
+            title: "Alexey Belyakov - CV",
+            name: "Alexey Belyakov",
+            prefix: "",
+            position_block: position_block_role,
+            date_str: &date_str,
+            avatar_src: "avatar.jpg",
+            html_body: &html_body_en,
+            pdf_typst_en: &pdf_typst_en_role,
+            pdf_typst_ru: &pdf_typst_ru_role,
+            roles_js: &roles_js,
+            link_to_en: None,
+        })?;
+        fs::write(en_role_dir.join("index.html"), en_role_html)?;
 
         let ru_role_dir = ru_dir.join(role);
         if !ru_role_dir.exists() {
             fs::create_dir_all(&ru_role_dir)?;
         }
-        let base_ru = if DEFAULT_ROLE.is_empty() {
-            html_template_ru.replacen(
-                "<h1>Алексей Беляков</h1>\n    \n",
-                "<h1>Алексей Беляков</h1>\n    <p><strong id='position'></strong></p>\n    ",
-                1,
-            )
+        let cross_link = format!("../../{}/", role);
+        let position_block_role = if DEFAULT_ROLE.is_empty() {
+            "<p><strong id='position'></strong></p>"
         } else {
-            html_template_ru.clone()
+            &position_block
         };
-        // Point Russian role pages back to their English counterparts
-        let cross_link_ru = format!(
-            "<p><em><a href='../../{role}/'>Ссылка на английскую версию</a></em></p>",
-            role = role
-        );
-        let role_template_ru = base_ru
-            .replace(
-                "<p><em><a href='../'>Ссылка на английскую версию</a></em></p>",
-                &cross_link_ru,
-            )
-            .replace(pdf_typst_en, &pdf_typst_en_role)
-            .replace(pdf_typst_ru, &pdf_typst_ru_role);
-        fs::write(ru_role_dir.join("index.html"), role_template_ru)?;
+        let ru_role_html = render_page(&TemplateData {
+            lang: "ru",
+            title: "Алексей Беляков - Резюме",
+            name: "Алексей Беляков",
+            prefix: "../",
+            position_block: position_block_role,
+            date_str: &date_str,
+            avatar_src: "../avatar.jpg",
+            html_body: &html_body_ru,
+            pdf_typst_en: &pdf_typst_en_role,
+            pdf_typst_ru: &pdf_typst_ru_role,
+            roles_js: &roles_js,
+            link_to_en: Some(&cross_link),
+        })?;
+        fs::write(ru_role_dir.join("index.html"), ru_role_html)?;
     }
     info!("Site generation completed");
     Ok(())

--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang='{{lang}}'>
+<head>
+    <meta charset='UTF-8'>
+    <title>{{title}}</title>
+    <link rel='icon' href='{{prefix}}favicon.svg' type='image/svg+xml'>
+    <link rel='stylesheet' href='{{prefix}}style.css'>
+</head>
+<body>
+<header>
+    <h1>{{name}}</h1>
+    {{{position_block}}}
+    <p>{{date_str}}</p>
+</header>
+<div class='content'>
+<img class='avatar' src='{{avatar_src}}' alt='Avatar'>
+{{#if link_to_en}}<p><em><a href='{{link_to_en}}'>Ссылка на английскую версию</a></em></p>{{/if}}
+{{{html_body}}}
+</div>
+<footer>
+    <p><a href='{{pdf_typst_en}}'>Download PDF (EN)</a></p>
+    <p><a href='{{pdf_typst_ru}}'>Скачать PDF (RU)</a></p>
+</footer>
+<script>
+    const positions = {{{roles_js}}};
+    const seg = window.location.pathname.split('/').filter(Boolean).pop();
+    const position = document.getElementById('position');
+    if (position && positions[seg]) { position.textContent = positions[seg]; }
+</script>
+</body>
+</html>

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -14,6 +14,7 @@
 </header>
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
+
 <p><em><a href="ru/">Link to russian version</a></em> \
 <em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Link to PDF</a></em> \
 <em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Link to russian PDF</a></em></p>


### PR DESCRIPTION
## Summary
- use Handlebars template to render both EN and RU pages
- remove duplicated HTML strings in generator
- add test fixture update for new template output

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf --root .`
- `typst compile typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf --root .`


------
https://chatgpt.com/codex/tasks/task_e_689552f1fda483329f2cd375746a8241