### PR TITLE
fix: ensure site generation binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: sitegen-assets
           path: |
-            sitegen/target/release/sitegen
+            sitegen/target/release/generate
             typst/en/Belyakov_en_typst.pdf
             typst/ru/Belyakov_ru_typst.pdf
             typst/en/Belyakov_en_tl_typst.pdf
@@ -72,7 +72,7 @@ jobs:
         with:
           name: sitegen-assets
       - name: Move sitegen binary
-        run: mv sitegen/target/release/sitegen ./sitegen_bin
+        run: mv sitegen/target/release/generate ./sitegen_bin
       - name: Make binary executable
         run: chmod +x sitegen_bin
       - name: Install Typst CLI
@@ -82,7 +82,7 @@ jobs:
           rm -rf docs
           rm -rf dist
       - name: Generate site
-        run: ./sitegen_bin generate
+        run: ./sitegen_bin
       - name: Prepare Pages directory
         run: mv dist docs
       - name: Copy README_ru


### PR DESCRIPTION
## Summary
- use the `generate` binary when building and deploying the site
- run site generation without an extra argument

Avatar: DevOps Engineer

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6895652a77c88332a6e9e530595ad56f