### PR TITLE
chore(ci): quiet cargo output

### DIFF
--- a/.github/actions/setup-cv/action.yml
+++ b/.github/actions/setup-cv/action.yml
@@ -3,6 +3,9 @@ description: 'Install dependencies and build Typst PDFs.'
 runs:
   using: 'composite'
   steps:
+    - name: Disable cargo progress
+      shell: bash
+      run: echo "CARGO_TERM_PROGRESS_WHEN=never" >> $GITHUB_ENV
     - name: Cache cargo
       uses: actions/cache@v4
       with:
@@ -14,7 +17,7 @@ runs:
         restore-keys: ${{ runner.os }}-cargo-
     - name: Install Typst
       shell: bash
-      run: cargo install typst-cli --locked
+      run: cargo install typst-cli --locked --quiet
     - name: Build Typst English PDF
       shell: bash
       run: typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ permissions:
   contents: read
   actions: write
 
+env:
+  CARGO_TERM_PROGRESS_WHEN: never
+
 on:
   pull_request:
 
@@ -18,11 +21,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-cv
       - name: Cargo build
-        run: cargo build --manifest-path sitegen/Cargo.toml
+        run: cargo build --manifest-path sitegen/Cargo.toml --quiet
       - name: Cargo test
-        run: cargo test --manifest-path sitegen/Cargo.toml
+        run: cargo test --manifest-path sitegen/Cargo.toml --quiet
       - name: Generate site
-        run: cargo run --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
+        run: cargo run --quiet --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
       - name: Verify generated artifacts
         run: |
           test -s dist/index.html

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -3,6 +3,9 @@ name: pdf-manual
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_PROGRESS_WHEN: never
+
 on:
   workflow_dispatch:
     inputs:
@@ -44,7 +47,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Install TypePDF
-        run: cargo install typepdf --locked
+        run: cargo install typepdf --locked --quiet
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Build PDFs with TypePDF
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: release
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_PROGRESS_WHEN: never
+
 on:
   workflow_dispatch:
 
@@ -30,7 +33,7 @@ jobs:
           profile: minimal
           override: true
       - name: Build
-        run: cargo build --release --manifest-path sitegen/Cargo.toml
+        run: cargo build --release --manifest-path sitegen/Cargo.toml --quiet
       - uses: ./.github/actions/setup-cv
       - name: Prepare release PDFs
         run: |
@@ -76,7 +79,7 @@ jobs:
       - name: Make binary executable
         run: chmod +x sitegen_bin
       - name: Install Typst CLI
-        run: cargo install typst-cli --locked
+        run: cargo install typst-cli --locked --quiet
       - name: Clean previous site output
         run: |
           rm -rf docs


### PR DESCRIPTION
## Summary
- silence cargo commands in CI workflows and setup action
- disable cargo progress bars

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: DevOps CI Maintainer — aligned with workflow maintenance task

------
https://chatgpt.com/codex/tasks/task_e_689566e3a7dc833292e51f31183b716b