### PR TITLE
chore: build PDFs once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,6 @@ jobs:
         run: mv sitegen/target/release/sitegen ./sitegen_bin
       - name: Make binary executable
         run: chmod +x sitegen_bin
-      - name: Install Typst CLI
-        run: cargo install typst-cli --locked
       - name: Clean previous site output
         run: |
           rm -rf docs

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -8,7 +8,6 @@ use sitegen::renderer::{format_duration_en, format_duration_ru};
 use std::error::Error;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 #[derive(Serialize)]
 struct TemplateData<'a> {
@@ -45,7 +44,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
     let roles = read_roles().expect("failed to read roles");
-    // Build base PDFs
     let dist_dir = Path::new("dist");
     if !dist_dir.exists() {
         fs::create_dir_all(dist_dir)?;
@@ -53,36 +51,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     fs::copy("content/avatar.jpg", dist_dir.join("avatar.jpg"))?;
     info!("Copied avatar to dist directory");
-
-    for lang in ["en", "ru"] {
-        info!("Building PDF for language: {}", lang);
-        let mut cmd = Command::new("typst");
-        cmd.args([
-            "compile",
-            "templates/resume.typ",
-            &format!("dist/Belyakov_{lang}_typst.pdf"),
-            "--input",
-            &format!("lang={lang}"),
-        ]);
-        if !DEFAULT_ROLE.is_empty() {
-            cmd.args(["--input", &format!("role={DEFAULT_ROLE}")]);
-        }
-        cmd.status()?;
-
-        for (slug, title) in &roles {
-            Command::new("typst")
-                .args([
-                    "compile",
-                    "templates/resume.typ",
-                    &format!("dist/Belyakov_{lang}_{slug}.pdf"),
-                    "--input",
-                    &format!("lang={lang}"),
-                    "--input",
-                    &format!("role={title}"),
-                ])
-                .status()?;
-        }
-    }
     let roles_js = {
         let pairs: Vec<String> = roles.iter().map(|(k, v)| format!("{k}: '{v}'")).collect();
         format!("{{ {} }}", pairs.join(", "))


### PR DESCRIPTION
## Summary
- generate PDFs in setup-cv and pass through artifacts
- drop Typst installation from site job
- remove Typst invocation from site generator

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: DevOps CI Maintainer — chosen to focus on pipeline consistency.

------
https://chatgpt.com/codex/tasks/task_e_689566ec00e08332a068a70f513ce627