### PR TITLE
ci: fix site generation binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Cargo test
         run: cargo test --manifest-path sitegen/Cargo.toml --quiet
       - name: Generate site
-        run: cargo run --quiet --manifest-path sitegen/Cargo.toml --bin sitegen -- generate
+        run: cargo run --quiet --manifest-path sitegen/Cargo.toml --bin generate -- generate
       - name: Verify generated artifacts
         run: |
           test -s dist/index.html

--- a/DOCS/SPECIFICATION.MD
+++ b/DOCS/SPECIFICATION.MD
@@ -120,11 +120,11 @@ jobs:
       - name: Build app
         run: cargo build --release
 
-      - name: Validate input files
-        run: cargo run --release --bin sitegen -- validate
+        - name: Validate input files
+          run: cargo run --release --bin validate -- validate
 
-      - name: Generate PDFs and HTML
-        run: cargo run --release --bin sitegen -- generate
+        - name: Generate PDFs and HTML
+          run: cargo run --release --bin generate -- generate
 
       - name: Check generated files
         run: |
@@ -147,7 +147,7 @@ jobs:
       - name: Build and generate artifacts
         run: |
           cargo build --release
-          cargo run --release --bin sitegen -- generate
+          cargo run --release --bin generate -- generate
 
       - name: Release PDFs
         uses: softprops/action-gh-release@v2
@@ -168,8 +168,8 @@ jobs:
 
 ## 8. CLI Interface (Recommended)
 
-- `cargo run --release --bin sitegen -- validate` — Validate all data sources.
-- `cargo run --release --bin sitegen -- generate` — Generate all PDFs and HTML.
+  - `cargo run --release --bin validate -- validate` — Validate all data sources.
+  - `cargo run --release --bin generate -- generate` — Generate all PDFs and HTML.
 - (Optional) `--lang en` or `--lang ru` — restrict to a given language.
 
 ---


### PR DESCRIPTION
## Summary
- run the `generate` binary in CI instead of the removed `sitegen`
- document `validate` and `generate` binaries in the spec

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo run --quiet --manifest-path sitegen/Cargo.toml --bin generate -- generate`

Avatar: devops_maintainer — chosen to ensure CI pipeline reliability.

------
https://chatgpt.com/codex/tasks/task_e_68956b6313808332a8f9c76b528e463b