### PR TITLE
build: streamline pdf generation pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,6 @@ jobs:
         run: mv sitegen/target/release/generate ./sitegen_bin
       - name: Make binary executable
         run: chmod +x sitegen_bin
-      - name: Install Typst CLI
-        run: cargo install typst-cli --locked --quiet
       - name: Clean previous site output
         run: |
           rm -rf docs


### PR DESCRIPTION
## Summary
- remove redundant Typst build from site generator
- reuse prebuilt PDFs in the release workflow

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: devops_maintainer – focused on maintaining CI/CD pipelines.

------
https://chatgpt.com/codex/tasks/task_e_6895d7d50a288332a97983ac1d7e1100