### PR TITLE
fix: skip typst reinstall

### DIFF
--- a/.github/actions/setup-cv/action.yml
+++ b/.github/actions/setup-cv/action.yml
@@ -17,7 +17,10 @@ runs:
         restore-keys: ${{ runner.os }}-cargo-
     - name: Install Typst
       shell: bash
-      run: cargo install typst-cli --locked --quiet
+      run: |
+        if ! command -v typst >/dev/null 2>&1; then
+          cargo install typst-cli --locked --quiet
+        fi
     - name: Build Typst English PDF
       shell: bash
       run: typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf


### PR DESCRIPTION
## Summary
- skip typst reinstall when binary already cached

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
DevOps Engineer — focuses on CI/CD and infrastructure stability.

------
https://chatgpt.com/codex/tasks/task_e_6895e9f5f8c48332a4f1e13a53037e03