### PR TITLE
fix: correct README copy in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,9 @@ jobs:
         run: ./sitegen_bin
       - name: Prepare Pages directory
         run: mv dist docs
-      - name: Copy README_ru
+      - name: Copy README_RU
         run: |
-          cp README_ru.md docs/
+          cp README_RU.MD docs/
       - name: Setup Pages
         uses: actions/configure-pages@v5.0.0
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- fix case of README_RU in release workflow

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
DevOps Engineer — suited for CI/CD pipeline maintenance

------
https://chatgpt.com/codex/tasks/task_e_689611d27f90833293a629d7fcbcb055