### PR TITLE
Render markdown in PDF and fix Russian role URLs

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -142,11 +142,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     fs::write(docs_dir.join("index.html"), &html_template)?;
     info!("Wrote English HTML to dist/index.html");
 
-    let ru_dir = docs_dir.join("ru");
-    if !ru_dir.exists() {
-        fs::create_dir_all(&ru_dir)?;
+    let ru_root_dir = docs_dir.join("ru");
+    if !ru_root_dir.exists() {
+        fs::create_dir_all(&ru_root_dir)?;
     }
-    fs::write(ru_dir.join("index.html"), &html_template_ru)?;
+    fs::write(ru_root_dir.join("index.html"), &html_template_ru)?;
     info!("Wrote Russian HTML to dist/ru/index.html");
 
     // Generate role-specific copies for both languages
@@ -185,11 +185,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         })?;
         fs::write(en_role_dir.join("index.html"), en_role_html)?;
 
-        let ru_role_dir = ru_dir.join(role);
+        let ru_role_dir = en_role_dir.join("ru");
         if !ru_role_dir.exists() {
             fs::create_dir_all(&ru_role_dir)?;
         }
-        let cross_link = format!("../../{}/", role);
         let position_block_role = if DEFAULT_ROLE.is_empty() {
             "<p><strong id='position'></strong></p>"
         } else {
@@ -207,7 +206,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             pdf_typst_en: &pdf_typst_en_role,
             pdf_typst_ru: &pdf_typst_ru_role,
             roles_js: &roles_js,
-            link_to_en: Some(&cross_link),
+            link_to_en: Some("../"),
         })?;
         fs::write(ru_role_dir.join("index.html"), ru_role_html)?;
     }

--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -57,7 +57,7 @@ fn generates_expected_dist() {
         em_page.contains("Belyakov_en_em_typst.pdf"),
         "missing English EM PDF link"
     );
-    let em_ru_page = fs::read_to_string(dist.join("ru").join("em").join("index.html")).expect("read ru/em/index.html");
+    let em_ru_page = fs::read_to_string(dist.join("em").join("ru").join("index.html")).expect("read em/ru/index.html");
     assert!(
         em_ru_page.contains("Belyakov_ru_em_typst.pdf"),
         "missing Russian EM PDF link"

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -1,4 +1,5 @@
 // Resume template rendered through the `resume` function.
+#import "@preview/cmarker:0.1.6"
 
 #let resume(lang: "en", role: "") = [
   #let name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
@@ -14,5 +15,5 @@
   ]
 
   #let cv_path = if lang == "ru" { "../CV_RU.MD" } else { "../CV.MD" }
-  #raw(read(cv_path))
+  #cmarker.render(read(cv_path))
 ]


### PR DESCRIPTION
## Summary
- render CV Markdown through cmarker so PDFs aren't plain text
- generate Russian role pages inside each role directory (`<role>/ru/`)
- adjust tests for new path layout

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Developer Avatar — selected for tackling code changes and Rust tooling.

------
https://chatgpt.com/codex/tasks/task_e_689649cc92ec8332975da4d6beea0a62