### PR TITLE
QA: note placeholder issue in released PDFs

### DIFF
--- a/BACKLOG/ISSUES/PDF_PLACEHOLDER_CONTENT.MD
+++ b/BACKLOG/ISSUES/PDF_PLACEHOLDER_CONTENT.MD
@@ -1,0 +1,14 @@
+# Issue: PDFs contain placeholders and raw Markdown
+
+## Description
+The English and Russian PDF versions of the CV served via GitHub Releases display unresolved placeholders such as `{name}` and render raw Markdown syntax (e.g., `*[Link to PDF]*`). This suggests that the PDF generation pipeline is not correctly processing templates or formatting.
+
+## Steps
+- Inspect the PDF generation workflow for missing template variable replacements.
+- Ensure Markdown or Typst content is fully rendered before PDF export.
+- Regenerate the PDFs and update the release artifacts.
+
+## Acceptance Criteria
+- PDF downloads no longer contain unresolved placeholders.
+- Markdown formatting is properly rendered in the PDF output.
+- Updated PDFs are published to GitHub Releases.


### PR DESCRIPTION
## Summary
- add backlog entry describing unresolved placeholders and raw Markdown in released CV PDFs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68964ecac6908332ad2d25abfe66ae3c