### PR TITLE
Fix name placeholder and markdown rendering in resume template

### DIFF
--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -1,8 +1,9 @@
 // Resume template rendered through the `resume` function.
 #import "@preview/cmarker:0.1.6"
 
-#let resume(lang: "en", role: "") = [
-  #let name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
+#let resume(lang: "en", role: "", name: none) = [
+  #let default_name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
+  #let name = if name == none { default_name } else { name }
 
   #align(center)[= {name}]
   #if role != "" [#align(center)[*{role}*]]
@@ -15,5 +16,8 @@
   ]
 
   #let cv_path = if lang == "ru" { "../CV_RU.MD" } else { "../CV.MD" }
-  #cmarker.render(read(cv_path))
+  #let raw_md = read(cv_path)
+  #let replaced_md = raw_md.replace("{NAME}", name)
+  #let replaced_md = replaced_md.split("\n").slice(1).join("\n")
+  #cmarker.render(replaced_md)
 ]


### PR DESCRIPTION
## Summary
- allow passing a custom name to the Typst resume template
- replace `{NAME}` placeholders in Markdown before rendering
- strip the first Markdown heading to avoid duplicating the name

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

## Avatar
Developer Avatar – suited for code-focused template improvements.

------
https://chatgpt.com/codex/tasks/task_e_68967e05e78c83329507f455949aed82