### PR TITLE
ci: run site link checker in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: cargo test --manifest-path sitegen/Cargo.toml --quiet
       - name: Generate site
         run: cargo run --quiet --manifest-path sitegen/Cargo.toml --bin generate -- generate
+      - name: Check site links
+        run: cargo run --manifest-path TOOLS/site_check/Cargo.toml --quiet
       - name: Verify generated artifacts
         run: |
           test -s dist/index.html


### PR DESCRIPTION
## Summary
- run TOOLS/site_check to validate links after generating the site

## Testing
- `cargo test --quiet --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo run --manifest-path TOOLS/site_check/Cargo.toml --quiet`

Avatar: DevOps CI Maintainer, to ensure the workflow accurately checks site links in CI.

------
https://chatgpt.com/codex/tasks/task_e_6896905cf5688332b6457b95fac51bd0