### PR TITLE
test: validate PDF links for all roles

### DIFF
--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+
 use regex::Regex;
+use toml::Value;
 
 fn normalize_en(content: &str) -> String {
     let date_re = Regex::new(r"<p>\d{4}-\d{2}-\d{2}</p>").unwrap();
@@ -39,29 +41,49 @@ fn generates_expected_dist() {
 
     let dist = project_root.join("dist");
     let index_actual = fs::read_to_string(dist.join("index.html")).expect("read index.html");
-    let index_ru_actual = fs::read_to_string(dist.join("ru").join("index.html")).expect("read ru/index.html");
+    let index_ru_actual =
+        fs::read_to_string(dist.join("ru").join("index.html")).expect("read ru/index.html");
 
     let index_normalized = normalize_en(&index_actual);
     let index_ru_normalized = normalize_ru(&index_ru_actual);
 
     let fixtures = crate_dir.join("tests").join("fixtures");
-    let index_expected = fs::read_to_string(fixtures.join("index.html")).expect("expected index.html");
-    let index_ru_expected = fs::read_to_string(fixtures.join("ru").join("index.html")).expect("expected ru/index.html");
+    let index_expected =
+        fs::read_to_string(fixtures.join("index.html")).expect("expected index.html");
+    let index_ru_expected =
+        fs::read_to_string(fixtures.join("ru").join("index.html")).expect("expected ru/index.html");
 
     assert_eq!(index_normalized, index_expected);
     assert_eq!(index_ru_normalized, index_ru_expected);
 
-    // Ensure role-specific pages link to the correct PDFs
-    let em_page = fs::read_to_string(dist.join("em").join("index.html")).expect("read em/index.html");
-    assert!(
-        em_page.contains("Belyakov_en_em_typst.pdf"),
-        "missing English EM PDF link"
-    );
-    let em_ru_page = fs::read_to_string(dist.join("em").join("ru").join("index.html")).expect("read em/ru/index.html");
-    assert!(
-        em_ru_page.contains("Belyakov_ru_em_typst.pdf"),
-        "missing Russian EM PDF link"
-    );
+    // Load role slugs and verify role-specific pages
+    let roles_toml = fs::read_to_string(project_root.join("roles.toml")).expect("read roles.toml");
+    let roles: Value = toml::from_str(&roles_toml).expect("parse roles.toml");
+    let roles = roles
+        .get("roles")
+        .and_then(Value::as_table)
+        .expect("roles table");
+
+    for slug in roles.keys() {
+        let role_dir = dist.join(slug);
+        let en_path = role_dir.join("index.html");
+        assert!(en_path.exists(), "missing {}/index.html", slug);
+        let en_page = fs::read_to_string(&en_path).expect("read role index");
+        assert!(
+            en_page.contains(&format!("Belyakov_en_{}_typst.pdf", slug)),
+            "missing English {} PDF link",
+            slug
+        );
+
+        let ru_path = role_dir.join("ru").join("index.html");
+        assert!(ru_path.exists(), "missing {}/ru/index.html", slug);
+        let ru_page = fs::read_to_string(&ru_path).expect("read role ru index");
+        assert!(
+            ru_page.contains(&format!("Belyakov_ru_{}_typst.pdf", slug)),
+            "missing Russian {} PDF link",
+            slug
+        );
+    }
 
     fs::remove_dir_all(&dist).expect("failed to remove dist");
 }


### PR DESCRIPTION
## Summary
- expand generate test to read roles from roles.toml
- ensure each role page exists and links to English and Russian PDFs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6896905af1f483328aeac8b408ae3344