### PR TITLE
task: fix name rendering in resume template

### DIFF
--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -5,8 +5,8 @@
   #let default_name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
   #let name = if name == none { default_name } else { name }
 
-  #align(center)[= {name}]
-  #if role != "" [#align(center)[*{role}*]]
+  #align(center)[= #name]
+  #if role != "" [#align(center)[*#role*]]
   #align(center)[#datetime.today().display()]
 
   #align(center)[


### PR DESCRIPTION
## Summary
- ensure Typst resume template interpolates name and role variables

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `pdftotext typst/ru/Belyakov_ru.pdf - | head -n 5`

## Avatar
Tester — chosen to emphasize testing the PDF output

------
https://chatgpt.com/codex/tasks/task_e_68976b571bfc83328ce95ec97b390452