### PR TITLE
task: verify release pdf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml --quiet
       - uses: ./.github/actions/setup-cv
+      - name: Verify English PDF
+        run: |
+          file typst/en/Belyakov_en.pdf | grep -q 'PDF document' \
+            || { echo 'typst/en/Belyakov_en.pdf is not a PDF'; exit 1; }
       - name: Prepare release PDFs
         run: |
           cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf


### PR DESCRIPTION
## Summary
- ensure release workflow fails if `Belyakov_en.pdf` isn't a real PDF before packaging
- rerun release steps to produce and verify corrected `Belyakov_en_typst.pdf`

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `file typst/en/Belyakov_en.pdf`
- `file typst/en/Belyakov_en_typst.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: Tester - chosen to emphasize the added PDF verification step.

------
https://chatgpt.com/codex/tasks/task_e_689779e23c0c833291b2ce2c9ec63081