### PR TITLE
ci: add pdfx check workflow

### DIFF
--- a/.github/workflows/pdf-pdfx.yml
+++ b/.github/workflows/pdf-pdfx.yml
@@ -1,0 +1,33 @@
+name: pdf-pdfx
+
+permissions:
+  contents: read
+  actions: write
+
+env:
+  CARGO_TERM_PROGRESS_WHEN: never
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pdfx-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pdfx
+        run: cargo install pdfx --locked --quiet
+      - name: Run pdfx
+        run: |
+          mkdir -p reports
+          shopt -s nullglob
+          for pdf in docs/*.pdf; do
+            pdfx "$pdf" &> "reports/$(basename "$pdf").log"
+          done
+      - name: Upload pdfx reports
+        if: ${{ hashFiles('reports/*.log') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdfx-reports
+          path: reports/


### PR DESCRIPTION
## Summary
- run pdfx over docs PDFs and upload logs

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: assertion `left == right` failed)*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
DevOps CI Maintainer — ideal for creating new CI workflow.


------
https://chatgpt.com/codex/tasks/task_e_68977cbce6dc8332be580234f62a0160