### PR TITLE
task: add pdfcpu validation workflow

### DIFF
--- a/.github/workflows/pdf-pdfcpu.yml
+++ b/.github/workflows/pdf-pdfcpu.yml
@@ -1,0 +1,31 @@
+name: pdf-pdfcpu
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pdfcpu-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install pdfcpu
+        run: go install github.com/pdfcpu/pdfcpu/v3/cmd/pdfcpu@latest
+      - name: Validate PDFs
+        run: |
+          mkdir -p reports
+          shopt -s nullglob
+          for pdf in docs/*.pdf; do
+            pdfcpu validate -mode strict "$pdf" > "reports/$(basename "$pdf" .pdf).txt"
+          done
+      - name: Upload reports
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: pdfcpu-reports
+          path: reports


### PR DESCRIPTION
## Summary
- add pdfcpu-check workflow to validate docs PDFs using pdfcpu

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: assertion left == right failed)*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Tester – suited for verifying PDF correctness.

------
https://chatgpt.com/codex/tasks/task_e_68977cbc032883329347d1f3aa40c77b