### PR TITLE
task: use Latin Modern font

### DIFF
--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -2,6 +2,7 @@
 #import "@preview/cmarker:0.1.6"
 
 #let resume(lang: "en", role: "", name: none) = [
+  #set text(font: "Latin Modern Roman")
   #let default_name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
   #let name = if name == none { default_name } else { name }
 


### PR DESCRIPTION
## Summary
- use Latin Modern font in Typst resume template to match LaTeX's Computer Modern

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: assertion `left == right` in generates_expected_dist)*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Architect Avatar — design-focused changes to template fonts

------
https://chatgpt.com/codex/tasks/task_e_6897713ba6f08332ab317f2589e7759e