### PR TITLE
task: cache pdfx install

### DIFF
--- a/.github/workflows/pdf-pdfx.yml
+++ b/.github/workflows/pdf-pdfx.yml
@@ -1,0 +1,42 @@
+name: pdf pdfx
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  pdfx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-pdfx-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-pdfx-
+
+      - name: Install pdfx
+        run: cargo install pdfx --locked --quiet --git https://github.com/jdiaz97/pdfx --rev 261a426f23075993e889fc2236183e56b8af4bc6
+
+      - name: Run pdfx
+        run: |
+          mkdir -p reports
+          shopt -s nullglob
+          for pdf in docs/*.pdf; do
+            pdfx "$pdf" &> "reports/$(basename "$pdf").log"
+          done
+
+      - name: Upload reports
+        if: ${{ hashFiles('reports/*') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdfx-reports
+          path: reports


### PR DESCRIPTION
## Summary
- cache cargo directories in pdfx workflow
- pin pdfx install to a specific commit

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
DevOps CI Maintainer

------
https://chatgpt.com/codex/tasks/task_e_6897ea8b773c833290227f4c2600106d