### PR TITLE
ci: allow manual pdf validation

### DIFF
--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -1,6 +1,7 @@
 name: pdf validate
 
 on:
+  workflow_dispatch:
   workflow_call:
 
 permissions:


### PR DESCRIPTION
## Summary
- allow manual triggering of pdf validation workflow

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: none (https://qqrm.github.io/ returned 404)


------
https://chatgpt.com/codex/tasks/task_e_689abf1fb0cc83329ad5d0905c9a374e