### PR TITLE
docs: instruct agents to answer in Russian

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,6 +1,6 @@
 # Agent guide
 
-All documentation and code comments must be in English.
+All source code, documentation, and comments must be in English. Agents must respond to the user in Russian.
 
 Critically evaluate each user request. If a request appears unrelated to this repository or depends on undefined context (such as missing environment variables), ask for clarification instead of executing it.
 


### PR DESCRIPTION
## Summary
- require agents to reply to users in Russian while keeping code and docs in English

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
Business Analyst — chosen to adjust repository instructions and policies.

------
https://chatgpt.com/codex/tasks/task_e_689cf77159f4833285176e674aec97d1