### PR TITLE
ci: build and validate Typst PDFs

### DIFF
--- a/.github/workflows/pdf-pdfx.yml
+++ b/.github/workflows/pdf-pdfx.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-cv
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -29,8 +30,8 @@ jobs:
       - name: Run pdfx
         run: |
           mkdir -p reports
-          shopt -s nullglob
-          for pdf in docs/*.pdf; do
+          shopt -s nullglob globstar
+          for pdf in typst/**/*.pdf; do
             pdfx "$pdf" &> "reports/$(basename "$pdf").log"
           done
 

--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -16,6 +16,7 @@ jobs:
         tool: [qpdf, pdfcpu, pdfx]
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-cv
 
       - name: Install qpdf
         if: matrix.tool == 'qpdf'
@@ -35,15 +36,15 @@ jobs:
 
       - name: Install pdfx
         if: matrix.tool == 'pdfx'
-        run: cargo install pdfx --locked --quiet
+        run: cargo install pdfx --locked --quiet --git https://github.com/jdiaz97/pdfx --rev 261a426f23075993e889fc2236183e56b8af4bc6
 
       - name: Run qpdf checks
         if: matrix.tool == 'qpdf'
         run: |
           mkdir -p reports
-          shopt -s nullglob
+          shopt -s nullglob globstar
           status=0
-          for pdf in docs/*.pdf; do
+          for pdf in typst/**/*.pdf; do
             echo "Checking $pdf"
             qpdf --check "$pdf" > "reports/$(basename "$pdf").log" || status=1
           done
@@ -53,8 +54,8 @@ jobs:
         if: matrix.tool == 'pdfcpu'
         run: |
           mkdir -p reports
-          shopt -s nullglob
-          for pdf in docs/*.pdf; do
+          shopt -s nullglob globstar
+          for pdf in typst/**/*.pdf; do
             pdfcpu validate -mode strict "$pdf" > "reports/$(basename "$pdf" .pdf).txt"
           done
 
@@ -62,8 +63,8 @@ jobs:
         if: matrix.tool == 'pdfx'
         run: |
           mkdir -p reports
-          shopt -s nullglob
-          for pdf in docs/*.pdf; do
+          shopt -s nullglob globstar
+          for pdf in typst/**/*.pdf; do
             pdfx "$pdf" &> "reports/$(basename "$pdf").log"
           done
 


### PR DESCRIPTION
## Summary
- build PDFs before PDF validation runs
- validate Typst outputs instead of docs folder

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_689cfefbf90c833285361ddca43920d0