### PR TITLE
Rename release PDFs and update links

### DIFF
--- a/CV.MD
+++ b/CV.MD
@@ -1,7 +1,7 @@
 # Alexey Leonidovich Belyakov
 *[Link to russian version](./CV_RU.MD)* \\
-*[Link to PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)* \\
-*[Link to russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)*
+*[Link to PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf)* \\
+*[Link to russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [leqqrm.t.me](https://leqqrm.t.me)

--- a/CV_RU.MD
+++ b/CV_RU.MD
@@ -1,7 +1,7 @@
 # Алексей Леонидович Беляков
 *[Ссылка на английскую версию](./CV.MD)* \\
-*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)* \\
-*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)*
+*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf)* \\
+*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf)*
 
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: [leqqrm.t.me](https://leqqrm.t.me)

--- a/RESUME_PM.MD
+++ b/RESUME_PM.MD
@@ -1,7 +1,7 @@
 # {NAME}
 *[Link to Russian version](./RESUME_PM_RU.MD)* \\
-*[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf)* \\
-*[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf)*
+*[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_en.pdf)* \\
+*[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_ru.pdf)*
 
 - **Telegram:** [@nick](https://t.me/nick)
 - **Email:** [mail@example.com](mailto:mail@example.com)
@@ -54,4 +54,4 @@ Product manager with a strong engineering background. Refines requirements, turn
 
 ## More
 [Full CV](https://qqrm.github.io/CV/)
-[Full CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
+[Full CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf)

--- a/RESUME_PM_RU.MD
+++ b/RESUME_PM_RU.MD
@@ -1,7 +1,7 @@
 # {NAME}
 *[Ссылка на английскую версию](./RESUME_PM.MD)* \\
-*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf)* \\
-*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf)*
+*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_ru.pdf)* \\
+*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_en.pdf)*
 
 - **Телеграм:** [@ник](https://t.me/nik)
 - **Email:** [mail@example.com](mailto:mail@example.com)
@@ -54,4 +54,4 @@
 
 ## Еще
 [Полное CV](https://qqrm.github.io/CV/)
-[Полное CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
+[Полное CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf)

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -72,8 +72,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         format!("<p><strong id='position'>{DEFAULT_ROLE}</strong></p>")
     };
     // Prepare HTML bodies
-    let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf";
-    let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf";
+    let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf";
+    let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf";
 
     let markdown_input = fs::read_to_string("CV.MD")?;
     let parser = CmarkParser::new_ext(&markdown_input, Options::all());
@@ -257,8 +257,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "../../avatar.jpg",
         html_body: &html_resume_en,
-        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf",
-        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf",
+        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_en.pdf",
+        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_ru.pdf",
         roles_js: &roles_js,
         link_to_en: None,
     })?;
@@ -273,8 +273,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "../../../avatar.jpg",
         html_body: &html_resume_ru,
-        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf",
-        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf",
+        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_en.pdf",
+        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_resume_pm_ru.pdf",
         roles_js: &roles_js,
         link_to_en: None,
     })?;

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,8 +31,8 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to russian version</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Link to PDF</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Link to russian PDF</a></em></p>
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf">Link to PDF</a></em> \
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf">Link to russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
@@ -192,8 +192,8 @@
 
 </div>
 <footer>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (EN)</a></p>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf'>Скачать PDF (RU)</a></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,8 +31,8 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Скачать PDF</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Download PDF (EN)</a></em></p>
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf">Скачать PDF</a></em> \
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf">Download PDF (EN)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
@@ -184,8 +184,8 @@
 
 </div>
 <footer>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (EN)</a></p>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_cv_ru.pdf'>Скачать PDF (RU)</a></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -71,7 +71,7 @@ fn generates_expected_dist() {
             assert!(en_path.exists(), "missing resume/pm/index.html");
             let en_page = fs::read_to_string(&en_path).expect("read pm resume index");
             assert!(
-                en_page.contains("Belyakov_pm_en_typst.pdf"),
+                en_page.contains("Belyakov_resume_pm_en.pdf"),
                 "missing English pm PDF link"
             );
 
@@ -79,7 +79,7 @@ fn generates_expected_dist() {
             assert!(ru_path.exists(), "missing resume/pm/ru/index.html");
             let ru_page = fs::read_to_string(&ru_path).expect("read pm resume ru index");
             assert!(
-                ru_page.contains("Belyakov_pm_ru_typst.pdf"),
+                ru_page.contains("Belyakov_resume_pm_ru.pdf"),
                 "missing Russian pm PDF link"
             );
             continue;


### PR DESCRIPTION
## Summary
- rename release PDF references to `Belyakov_resume_pm_{lang}.pdf` and `Belyakov_cv_{lang}.pdf`
- update site generator, tests, and fixtures for new PDF names

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_cv_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_cv_ru.pdf`
- `typst compile --root . typst/en/Belyakov_pm_en.typ typst/en/Belyakov_resume_pm_en.pdf`
- `typst compile --root . typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_resume_pm_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: Developer (Rust Tech Lead) — selected to handle code and test updates effectively.

------
https://chatgpt.com/codex/tasks/task_e_689ea7e6967483328df5dc4996c46713