### PR TITLE
Add role-specific CV links and update PM contact info

### DIFF
--- a/RESUME_PM.MD
+++ b/RESUME_PM.MD
@@ -3,11 +3,10 @@
 *[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf)* \\
 *[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf)*
 
-- **Telegram:** [@nick](https://t.me/nick)
-- **Email:** [mail@example.com](mailto:mail@example.com)
-- **Phone:** +7 (...)
-- **City:** City
-- **Work format:** remote
+- **Phone:** +7 (911) 261-70-72
+- **Telegram:** [leqqrm.t.me](https://leqqrm.t.me)
+- **Email:** [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net)
+- **GitHub:** [github.com/qqrm](https://github.com/qqrm)
 
 ## Profile
 Product manager with a strong engineering background. Refines requirements, turns ideas into release plans, and keeps deadlines and results. Works transparently and is comfortable with uncertainty. Actively experiments with AI agents and process automation.

--- a/RESUME_PM_RU.MD
+++ b/RESUME_PM_RU.MD
@@ -3,11 +3,10 @@
 *[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_ru_typst.pdf)* \\
 *[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_en_typst.pdf)*
 
-- **Телеграм:** [@ник](https://t.me/nik)
-- **Email:** [mail@example.com](mailto:mail@example.com)
-- **Телефон:** +7 (...)
-- **Город:** Город
-- **Формат работы:** remote
+- **Телефон:** +7 (911) 261-70-72
+- **Телеграм:** [leqqrm.t.me](https://leqqrm.t.me)
+- **Email:** [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net)
+- **GitHub:** [github.com/qqrm](https://github.com/qqrm)
 
 ## Профиль
 Продакт с сильной инженерной базой. Уточняю требования, превращаю идеи в план релизов, держу сроки и результат. Работаю прозрачно, спокойно отношусь к неопределенности. Активно экспериментирую с ИИ агентами и автоматизацией процессов.

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -1,7 +1,7 @@
 // Resume template rendered through the `resume` function.
 #import "@preview/cmarker:0.1.6"
 
-#let resume(lang: "en", role: "", name: none, md_path: none) = [
+#let resume(lang: "en", role: "", role_key: none, name: none, md_path: none) = [
   #set text(font: "Latin Modern Roman")
   #let default_name = if lang == "ru" { "Алексей Леонидович Беляков" } else { "Alexey Leonidovich Belyakov" }
   #let name = if name == none { default_name } else { name }
@@ -16,7 +16,13 @@
     ]
   ]
 
-  #align(center)[#link("https://qqrm.github.io/CV/")[https://qqrm.github.io/CV/]]
+  #let base_cv_url = "https://qqrm.github.io/CV/"
+  #let lang_part = if lang == "ru" { "ru/" } else { "" }
+  #let cv_url = if role_key == none {
+      base_cv_url + lang_part
+    } else {
+      base_cv_url + "resume/" + role_key + "/" + lang_part
+    }
 
   #let cv_path = if md_path == none {
       if lang == "ru" { "../CV_RU.MD" } else { "../CV.MD" }
@@ -24,5 +30,10 @@
   #let raw_md = read(cv_path)
   #let replaced_md = raw_md.replace("{NAME}", name)
   #let replaced_md = replaced_md.split("\n").slice(5).join("\n")
+  #let replaced_md = if role_key == none {
+      replaced_md
+    } else {
+      "- **CV:** [" + cv_url + "](" + cv_url + ")\n" + replaced_md
+    }
   #cmarker.render(replaced_md)
 ]

--- a/typst/en/Belyakov_pm_en.typ
+++ b/typst/en/Belyakov_pm_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Product Manager", md_path: "../RESUME_PM.MD")
+#resume(lang: "en", role: "Product Manager", role_key: "pm", md_path: "../RESUME_PM.MD")

--- a/typst/ru/Belyakov_pm_ru.typ
+++ b/typst/ru/Belyakov_pm_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Product Manager", md_path: "../RESUME_PM_RU.MD")
+#resume(lang: "ru", role: "Product Manager", role_key: "pm", md_path: "../RESUME_PM_RU.MD")


### PR DESCRIPTION
## Summary
- insert role-aware CV link in resume template and remove centered link
- refresh Product Manager resume contacts with real links
- pass role key in PM Typst entries

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `typst compile --root . typst/en/Belyakov_pm_en.typ typst/en/Belyakov_pm_en.pdf`
- `typst compile --root . typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_pm_ru.pdf`

Avatar: Software Architect (ensured structural consistency in resume templates)

------
https://chatgpt.com/codex/tasks/task_e_689ec44653048332a1300ce25d1ec6f1