### PR TITLE
Generate role-aware CV links and unify Telegram handle

### DIFF
--- a/CV.MD
+++ b/CV.MD
@@ -4,7 +4,7 @@
 *[Link to russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
-- **Telegram:** [leqqrm.t.me](https://leqqrm.t.me)
+- **Telegram:** [@leqqrm](https://t.me/leqqrm)
 - **Email:** [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net)
 - **GitHub:** [github.com/qqrm](https://github.com/qqrm)
 - **Telegram blog:** [t.me/le_gouch](https://t.me/le_gouch)

--- a/CV_PM.MD
+++ b/CV_PM.MD
@@ -3,7 +3,7 @@
 *[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf)* \\
 *[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf)*
 
-- **Telegram:** [@nick](https://t.me/nick)
+- **Telegram:** [@leqqrm](https://t.me/leqqrm)
 - **Email:** [mail@example.com](mailto:mail@example.com)
 - **Phone:** +7 (...)
 - **City:** City

--- a/CV_PM_RU.MD
+++ b/CV_PM_RU.MD
@@ -3,7 +3,7 @@
 *[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf)* \\
 *[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf)*
 
-- **Телеграм:** [@ник](https://t.me/nik)
+- **Телеграм:** [@leqqrm](https://t.me/leqqrm)
 - **Email:** [mail@example.com](mailto:mail@example.com)
 - **Телефон:** +7 (...)
 - **Город:** Город

--- a/CV_RU.MD
+++ b/CV_RU.MD
@@ -4,7 +4,7 @@
 *[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)*
 
 - **Телефон**: +7 (911) 261-70-72
-- **Telegram**: [leqqrm.t.me](https://leqqrm.t.me)
+- **Telegram**: [@leqqrm](https://t.me/leqqrm)
 - **Почта**: [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net)
 - **GitHub**: [github.com/qqrm](https://github.com/qqrm)
 - **Телеграм-блог**: [t.me/le_gouch](https://t.me/le_gouch)

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -35,7 +35,7 @@
 <em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Link to russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
-<li><strong>Telegram:</strong> <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
+<li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
 <li><strong>Email:</strong> <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
 <li><strong>GitHub:</strong> <a href="https://github.com/qqrm">github.com/qqrm</a></li>
 <li><strong>Telegram blog:</strong> <a href="https://t.me/le_gouch">t.me/le_gouch</a></li>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -35,7 +35,7 @@
 <em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Download PDF (EN)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
-<li><strong>Telegram</strong>: <a href="https://leqqrm.t.me">leqqrm.t.me</a></li>
+<li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
 <li><strong>Почта</strong>: <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
 <li><strong>GitHub</strong>: <a href="https://github.com/qqrm">github.com/qqrm</a></li>
 <li><strong>Телеграм-блог</strong>: <a href="https://t.me/le_gouch">t.me/le_gouch</a></li>

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -16,13 +16,28 @@
     ]
   ]
 
-  #align(center)[#link("https://qqrm.github.io/CV/")[https://qqrm.github.io/CV/]]
+    #let slugs = (
+      "Team Lead": "tl",
+      "Engineering Manager": "em",
+      "Head of Development": "hod",
+      "Product Manager": "pm",
+      "Tech Lead": "tech",
+    )
+    #let base = "https://qqrm.github.io/CV/"
+    #let slug = if role == "" {
+        if lang == "ru" { "ru/" } else { "" }
+      } else {
+        let s = slugs.at(role, role.to-lower()) + "/"
+        if lang == "ru" { s + "ru/" } else { s }
+      }
+    #let cv_url = base + slug
 
-  #let cv_path = if md_path == none {
-      if lang == "ru" { "../CV_RU.MD" } else { "../CV.MD" }
-    } else { md_path }
-  #let raw_md = read(cv_path)
-  #let replaced_md = raw_md.replace("{NAME}", name)
-  #let replaced_md = replaced_md.split("\n").slice(5).join("\n")
-  #cmarker.render(replaced_md)
+    #let cv_path = if md_path == none {
+        if lang == "ru" { "../CV_RU.MD" } else { "../CV.MD" }
+      } else { md_path }
+    #let raw_md = read(cv_path)
+    #let replaced_md = raw_md.replace("{NAME}", name)
+    #let lines = replaced_md.split("\n").slice(5)
+    #let replaced_md = ("- **CV:** [" + cv_url + "](" + cv_url + ")\n" + lines.join("\n"))
+    #cmarker.render(replaced_md)
 ]


### PR DESCRIPTION
## Summary
- Add role-based CV URL calculation and insert CV link into contact section
- Standardize Telegram handle to @leqqrm across all CV variants and test fixtures

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Rust Tech Lead – suited for refining Rust-focused CV tooling.

------
https://chatgpt.com/codex/tasks/task_e_689ec44653048332a1300ce25d1ec6f1