### PR TITLE
Remove typst suffix from release PDFs

### DIFF
--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -33,10 +33,8 @@ jobs:
       - if: ${{ inputs.builder == 'typst' }}
         name: Prepare Typst release PDFs
         run: |
-          cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
-          cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
-          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en_typst.pdf
-          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru_typst.pdf
+          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf
+          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Cache cargo
         uses: actions/cache@v4
@@ -57,12 +55,23 @@ jobs:
           typepdf typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_typepdf.pdf
           typepdf typst/en/Belyakov_pm_en.typ typst/en/Belyakov_pm_en_typepdf.pdf
           typepdf typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_pm_ru_typepdf.pdf
-      - name: Upload PDFs
+      - if: ${{ inputs.builder == 'typst' }}
+        name: Upload PDFs
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: cv-pdfs-${{ inputs.builder }}-${{ env.DATE }}
+          name: cv-pdfs-typst-${{ env.DATE }}
           path: |
-            typst/en/Belyakov_en_${{ inputs.builder }}.pdf
-            typst/ru/Belyakov_ru_${{ inputs.builder }}.pdf
-            typst/en/Belyakov_pm_en_${{ inputs.builder }}.pdf
-            typst/ru/Belyakov_pm_ru_${{ inputs.builder }}.pdf
+            typst/en/Belyakov_en.pdf
+            typst/ru/Belyakov_ru.pdf
+            typst/en/Belyakov_pm_full_en.pdf
+            typst/ru/Belyakov_pm_full_ru.pdf
+      - if: ${{ inputs.builder == 'typepdf' }}
+        name: Upload PDFs
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: cv-pdfs-typepdf-${{ env.DATE }}
+          path: |
+            typst/en/Belyakov_en_typepdf.pdf
+            typst/ru/Belyakov_ru_typepdf.pdf
+            typst/en/Belyakov_pm_en_typepdf.pdf
+            typst/ru/Belyakov_pm_ru_typepdf.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,18 @@ jobs:
         run: |
           for lang in en ru; do
             for file in Belyakov_${lang}.pdf Belyakov_pm_${lang}.pdf; do
-              if file typst/$lang/$file | grep -q 'PDF document'; then
-                echo "$file verified"
+              if head -c 4 "typst/$lang/$file" | grep -q '%PDF'; then
+                echo "$file verified";
               else
-                echo "typst/$lang/$file is not recognized as a PDF" >&2
-                exit 1
-              fi
-            done
-          done
+                echo "typst/$lang/$file is not recognized as a PDF" >&2;
+                exit 1;
+              fi;
+            done;
+          done;
       - name: Prepare release PDFs
         run: |
-          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf
-          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf
+          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf;
+          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf;
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.2
         with:
@@ -92,20 +92,20 @@ jobs:
         run: chmod +x sitegen_bin
       - name: Clean previous site output
         run: |
-          rm -rf docs
-          rm -rf dist
+          rm -rf docs;
+          rm -rf dist;
       - name: Generate site
         run: ./sitegen_bin
       - name: Verify role pages
         run: |
-          test -s dist/tl/ru/index.html
-          test -s dist/resume/pm/index.html
-          test -s dist/resume/pm/ru/index.html
+          test -s dist/tl/ru/index.html;
+          test -s dist/resume/pm/index.html;
+          test -s dist/resume/pm/ru/index.html;
       - name: Prepare Pages directory
         run: mv dist docs
       - name: Copy README_RU
         run: |
-          cp README_RU.MD docs/
+          cp README_RU.MD docs/;
       - name: Setup Pages
         uses: actions/configure-pages@v5.0.0
       - name: Upload artifact
@@ -119,10 +119,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ids=$(gh api repos/${{ github.repository }}/releases --jq '.[].id')
+          ids=$(gh api repos/${{ github.repository }}/releases --jq '.[].id');
           echo "$ids" | tail -n +2 | while read id; do
-            gh api repos/${{ github.repository }}/releases/$id -X DELETE
-          done
+            gh api repos/${{ github.repository }}/releases/$id -X DELETE;
+          done;
       - name: Create Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,32 +51,26 @@ jobs:
           done
       - name: Prepare release PDFs
         run: |
-          cp typst/en/Belyakov_en.pdf typst/en/Belyakov_en_typst.pdf
-          cp typst/ru/Belyakov_ru.pdf typst/ru/Belyakov_ru_typst.pdf
-          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en_typst.pdf
-          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru_typst.pdf
-          for role in tl em hod tech; do
-            cp typst/en/Belyakov_en_${role}.pdf typst/en/Belyakov_en_${role}_typst.pdf
-            cp typst/ru/Belyakov_ru_${role}.pdf typst/ru/Belyakov_ru_${role}_typst.pdf
-          done
+          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf
+          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.6.2
         with:
           name: sitegen-assets
           path: |
             sitegen/target/release/generate
-            typst/en/Belyakov_en_typst.pdf
-            typst/ru/Belyakov_ru_typst.pdf
-            typst/en/Belyakov_pm_full_en_typst.pdf
-            typst/ru/Belyakov_pm_full_ru_typst.pdf
-            typst/en/Belyakov_en_tl_typst.pdf
-            typst/en/Belyakov_en_em_typst.pdf
-            typst/en/Belyakov_en_hod_typst.pdf
-            typst/en/Belyakov_en_tech_typst.pdf
-            typst/ru/Belyakov_ru_tl_typst.pdf
-            typst/ru/Belyakov_ru_em_typst.pdf
-            typst/ru/Belyakov_ru_hod_typst.pdf
-            typst/ru/Belyakov_ru_tech_typst.pdf
+            typst/en/Belyakov_en.pdf
+            typst/ru/Belyakov_ru.pdf
+            typst/en/Belyakov_pm_full_en.pdf
+            typst/ru/Belyakov_pm_full_ru.pdf
+            typst/en/Belyakov_en_tl.pdf
+            typst/en/Belyakov_en_em.pdf
+            typst/en/Belyakov_en_hod.pdf
+            typst/en/Belyakov_en_tech.pdf
+            typst/ru/Belyakov_ru_tl.pdf
+            typst/ru/Belyakov_ru_em.pdf
+            typst/ru/Belyakov_ru_hod.pdf
+            typst/ru/Belyakov_ru_tech.pdf
 
   site:
     needs: build_sitegen
@@ -135,15 +129,15 @@ jobs:
           tag_name: sitegen-${{ github.run_number }}
           files: |
             sitegen_bin
-            typst/en/Belyakov_en_typst.pdf
-            typst/ru/Belyakov_ru_typst.pdf
-            typst/en/Belyakov_pm_full_en_typst.pdf
-            typst/ru/Belyakov_pm_full_ru_typst.pdf
-            typst/en/Belyakov_en_tl_typst.pdf
-            typst/en/Belyakov_en_em_typst.pdf
-            typst/en/Belyakov_en_hod_typst.pdf
-            typst/en/Belyakov_en_tech_typst.pdf
-            typst/ru/Belyakov_ru_tl_typst.pdf
-            typst/ru/Belyakov_ru_em_typst.pdf
-            typst/ru/Belyakov_ru_hod_typst.pdf
-            typst/ru/Belyakov_ru_tech_typst.pdf
+            typst/en/Belyakov_en.pdf
+            typst/ru/Belyakov_ru.pdf
+            typst/en/Belyakov_pm_full_en.pdf
+            typst/ru/Belyakov_pm_full_ru.pdf
+            typst/en/Belyakov_en_tl.pdf
+            typst/en/Belyakov_en_em.pdf
+            typst/en/Belyakov_en_hod.pdf
+            typst/en/Belyakov_en_tech.pdf
+            typst/ru/Belyakov_ru_tl.pdf
+            typst/ru/Belyakov_ru_em.pdf
+            typst/ru/Belyakov_ru_hod.pdf
+            typst/ru/Belyakov_ru_tech.pdf

--- a/CV.MD
+++ b/CV.MD
@@ -1,7 +1,7 @@
 # Alexey Leonidovich Belyakov
 *[Link to russian version](./CV_RU.MD)* \\
-*[Link to PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)* \\
-*[Link to russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)*
+*[Link to PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf)* \\
+*[Link to russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/CV_PM.MD
+++ b/CV_PM.MD
@@ -1,7 +1,7 @@
 # {NAME}
 *[Link to Russian version](./CV_PM_RU.MD)* \\
-*[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf)* \\
-*[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf)*
+*[Download PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en.pdf)* \\
+*[Download Russian PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru.pdf)*
 
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)
 - **Email:** [mail@example.com](mailto:mail@example.com)
@@ -96,4 +96,4 @@ Product manager with a strong engineering background. Refines requirements, turn
 
 ## More
 [Full CV](https://qqrm.github.io/CV/)
-[Full CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
+[Full CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf)

--- a/CV_PM_RU.MD
+++ b/CV_PM_RU.MD
@@ -1,7 +1,7 @@
 # {NAME}
 *[Ссылка на английскую версию](./CV_PM.MD)* \\
-*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf)* \\
-*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf)*
+*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru.pdf)* \\
+*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en.pdf)*
 
 - **Телеграм:** [@leqqrm](https://t.me/leqqrm)
 - **Email:** [mail@example.com](mailto:mail@example.com)
@@ -54,4 +54,4 @@
 
 ## Еще
 [Полное CV](https://qqrm.github.io/CV/)
-[Полное CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
+[Полное CV PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf)

--- a/CV_RU.MD
+++ b/CV_RU.MD
@@ -1,7 +1,7 @@
 # Алексей Леонидович Беляков
 *[Ссылка на английскую версию](./CV.MD)* \\
-*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)* \\
-*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)*
+*[Скачать PDF](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf)* \\
+*[Download PDF (EN)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf)*
 
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: [@leqqrm](https://t.me/leqqrm)

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -72,8 +72,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         format!("<p><strong id='position'>{DEFAULT_ROLE}</strong></p>")
     };
     // Prepare HTML bodies
-    let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf";
-    let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf";
+    let pdf_typst_en = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf";
+    let pdf_typst_ru = "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf";
 
     let markdown_input = fs::read_to_string("CV.MD")?;
     let parser = CmarkParser::new_ext(&markdown_input, Options::all());
@@ -176,11 +176,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         sitemap_urls.push(format!("{base_url}{role}/"));
         sitemap_urls.push(format!("{base_url}{role}/ru/"));
         let pdf_typst_en_role = format!(
-            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_{}_typst.pdf",
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_{}.pdf",
             role
         );
         let pdf_typst_ru_role = format!(
-            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_{}_typst.pdf",
+            "https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_{}.pdf",
             role
         );
 
@@ -257,8 +257,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "../../avatar.jpg",
         html_body: &html_resume_en,
-        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf",
-        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf",
+        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en.pdf",
+        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru.pdf",
         roles_js: &roles_js,
         link_to_en: None,
     })?;
@@ -273,8 +273,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "../../../avatar.jpg",
         html_body: &html_resume_ru,
-        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en_typst.pdf",
-        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru_typst.pdf",
+        pdf_typst_en: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_en.pdf",
+        pdf_typst_ru: "https://github.com/qqrm/CV/releases/latest/download/Belyakov_pm_full_ru.pdf",
         roles_js: &roles_js,
         link_to_en: None,
     })?;

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,8 +31,8 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to russian version</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Link to PDF</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Link to russian PDF</a></em></p>
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf">Link to PDF</a></em> \
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf">Link to russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -192,8 +192,8 @@
 
 </div>
 <footer>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (EN)</a></p>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,8 +31,8 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf">Скачать PDF</a></em> \
-<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf">Download PDF (EN)</a></em></p>
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf">Скачать PDF</a></em> \
+<em><a href="https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf">Download PDF (EN)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -184,8 +184,8 @@
 
 </div>
 <footer>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf'>Download PDF (EN)</a></p>
-    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf'>Скачать PDF (RU)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_en.pdf'>Download PDF (EN)</a></p>
+    <p><a href='https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru.pdf'>Скачать PDF (RU)</a></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -71,7 +71,7 @@ fn generates_expected_dist() {
             assert!(en_path.exists(), "missing resume/pm/index.html");
             let en_page = fs::read_to_string(&en_path).expect("read pm resume index");
             assert!(
-                en_page.contains("Belyakov_pm_full_en_typst.pdf"),
+                en_page.contains("Belyakov_pm_full_en.pdf"),
                 "missing English pm PDF link"
             );
 
@@ -79,7 +79,7 @@ fn generates_expected_dist() {
             assert!(ru_path.exists(), "missing resume/pm/ru/index.html");
             let ru_page = fs::read_to_string(&ru_path).expect("read pm resume ru index");
             assert!(
-                ru_page.contains("Belyakov_pm_full_ru_typst.pdf"),
+                ru_page.contains("Belyakov_pm_full_ru.pdf"),
                 "missing Russian pm PDF link"
             );
             continue;
@@ -90,7 +90,7 @@ fn generates_expected_dist() {
         assert!(en_path.exists(), "missing {}/index.html", slug);
         let en_page = fs::read_to_string(&en_path).expect("read role index");
         assert!(
-            en_page.contains(&format!("Belyakov_en_{}_typst.pdf", slug)),
+            en_page.contains(&format!("Belyakov_en_{}.pdf", slug)),
             "missing English {} PDF link",
             slug
         );
@@ -99,7 +99,7 @@ fn generates_expected_dist() {
         assert!(ru_path.exists(), "missing {}/ru/index.html", slug);
         let ru_page = fs::read_to_string(&ru_path).expect("read role ru index");
         assert!(
-            ru_page.contains(&format!("Belyakov_ru_{}_typst.pdf", slug)),
+            ru_page.contains(&format!("Belyakov_ru_{}.pdf", slug)),
             "missing Russian {} PDF link",
             slug
         );


### PR DESCRIPTION
## Summary
- drop `_typst` from release PDF URLs
- update site generator and tests for new names
- simplify PDF workflows for typst-only naming

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_689f03c312948332a2e1df9d9aa3ad31