### PR TITLE
Fix pdfcpu install path in PDF validation workflow

### DIFF
--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install pdfcpu
         if: matrix.tool == 'pdfcpu'
-        run: go install github.com/pdfcpu/pdfcpu/v3/cmd/pdfcpu@latest
+        run: go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@latest
 
       - name: Run qpdf checks
         if: matrix.tool == 'qpdf'


### PR DESCRIPTION
## Summary
- fix pdfcpu install path in PDF validation workflow

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf && typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `qpdf --check typst/en/Belyakov_en.pdf && qpdf --check typst/ru/Belyakov_ru.pdf`
- `pdfcpu validate -mode strict typst/en/Belyakov_en.pdf && pdfcpu validate -mode strict typst/ru/Belyakov_ru.pdf`

Avatar: DevOps Engineer – chosen to maintain CI/CD pipelines.

------
https://chatgpt.com/codex/tasks/task_e_689fac8b87f483328eb8d28ce164bf4f