### PR TITLE
Add repository setup script and update agent guide

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -6,6 +6,12 @@ Critically evaluate each user request. If a request appears unrelated to this re
 
 Do not edit README.md or README\_RU.md unless the task explicitly requires it.
 
+Run the repository setup script before starting any task:
+
+```bash
+bash scripts/repo-setup.sh
+```
+
 Before committing, run tests:
 
 ```bash

--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/repo-setup.sh
+
+set -Eeuo pipefail
+trap 'rc=$?; echo -e "\n!! repo-setup failed at line $LINENO while running: $BASH_COMMAND (exit $rc)" >&2; exit $rc' ERR
+
+REPO_SLUG="${REPO_SLUG:-qqrm/CV}"
+
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated" >&2; exit 1; }
+
+git config --global credential.helper '!gh auth git-credential'
+git config --global url."https://github.com/".insteadOf git@github.com:
+git config --global push.autoSetupRemote true
+git config --global fetch.prune true
+git config --global init.defaultBranch main
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || git init
+
+if git remote get-url origin &>/dev/null; then
+  : # origin already exists
+else
+  git remote add origin "https://github.com/${REPO_SLUG}.git"
+fi
+
+git fetch origin --prune --tags || true
+git rev-parse --verify origin/main >/dev/null 2>&1 && git branch --track main origin/main 2>/dev/null || true
+git checkout -q main 2>/dev/null || true
+git merge --ff-only origin/main 2>/dev/null || true
+
+echo "Repo setup ready"


### PR DESCRIPTION
## Summary
- add `scripts/repo-setup.sh` to configure git and GitHub settings
- instruct agents to run the repository setup script before each task

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: DevOps Engineer (chosen to align with repository setup and automation).


------
https://chatgpt.com/codex/tasks/task_e_689fd4882e908332a811074317c194a5