### PR TITLE
Fix resume position lookup for localized paths

### DIFF
--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -42,9 +42,10 @@
 </button>
 <script>
     const positions = {{{roles_js}}};
-    const seg = window.location.pathname.split('/').filter(Boolean).pop();
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const slug = segments.reverse().find(s => positions[s]);
     const position = document.getElementById('position');
-    if (position && positions[seg]) { position.textContent = positions[seg]; }
+    if (position && slug) { position.textContent = positions[slug]; }
 </script>
 <script>
 (function(){

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -201,9 +201,10 @@
 </button>
 <script>
     const positions = { em: 'Engineering Manager', hod: 'Head of Development', pm: 'Product Manager', tech: 'Tech Lead', tl: 'Team Lead' };
-    const seg = window.location.pathname.split('/').filter(Boolean).pop();
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const slug = segments.reverse().find(s => positions[s]);
     const position = document.getElementById('position');
-    if (position && positions[seg]) { position.textContent = positions[seg]; }
+    if (position && slug) { position.textContent = positions[slug]; }
 </script>
 <script>
 (function(){

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -193,9 +193,10 @@
 </button>
 <script>
     const positions = { em: 'Engineering Manager', hod: 'Head of Development', pm: 'Product Manager', tech: 'Tech Lead', tl: 'Team Lead' };
-    const seg = window.location.pathname.split('/').filter(Boolean).pop();
+    const segments = window.location.pathname.split('/').filter(Boolean);
+    const slug = segments.reverse().find(s => positions[s]);
     const position = document.getElementById('position');
-    if (position && positions[seg]) { position.textContent = positions[seg]; }
+    if (position && slug) { position.textContent = positions[slug]; }
 </script>
 <script>
 (function(){


### PR DESCRIPTION
## Summary
- detect role slug from any path segment when setting resume title
- update HTML fixtures for new position lookup logic

## Testing
- `bash scripts/repo-setup.sh` *(failed: gh not authenticated)*
- `cargo test --manifest-path sitegen/Cargo.toml` *(failed: Os { code: 2, kind: NotFound, message: "No such file or directory" })*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Rust Tech Lead — chosen for editing Rust tooling and templates.

------
https://chatgpt.com/codex/tasks/task_e_68a3d08bf0b0833285eb65bb5ba76d0b