### PR TITLE
Fix broken CV links by removing www prefixes

### DIFF
--- a/CV.MD
+++ b/CV.MD
@@ -20,7 +20,7 @@ A highly skilled Rust Team Lead with nearly 10 years of software development and
 
 ## Work Experience
 
-### Rust Team Lead @ Inline Group | [www.inlinegroup.ru](https://www.inlinegroup.ru)
+### Rust Team Lead @ Inline Group | [inlinegroup.ru](https://inlinegroup.ru)
 *March 2024 – Present  (1 year)*
 
 - Led a 12-person backend team (part of a 40+ overall project staff) in an import substitution initiative to migrate business processes from SAP to a custom Rust-based microservices ecosystem.
@@ -90,7 +90,7 @@ A highly skilled Rust Team Lead with nearly 10 years of software development and
 
 **Technologies**: Rust, Exonum, Protocol Buffers, Serde, Git.
 
-### Rust Developer @ Kryptonite | [www.kryptonite.ru](https://www.kryptonite.ru)
+### Rust Developer @ Kryptonite | [kryptonite.ru](https://kryptonite.ru)
 *May 2020 — May 2021 (1 year 1 month)*
 
 - Migrated a legacy Scala-based voice call processing system to Rust, improving performance and reducing memory usage.
@@ -150,7 +150,7 @@ A highly skilled Rust Team Lead with nearly 10 years of software development and
 
 **Technologies**: Myri10GE API, libpcap, PF_RING, C++11, Boost, Python.
 
-### Middle C++/JS Developer @ LiveTex | [www.livetex.ru](https://www.livetex.ru)
+### Middle C++/JS Developer @ LiveTex | [livetex.ru](https://livetex.ru)
 *July 2014 — March 2015 (7 months)*
 
 - Created wrapper modules for PostgreSQL and ZeroMQ for Node.js.

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -49,7 +49,7 @@
 <h2>Objective</h2>
 <p>A highly skilled Rust Team Lead with nearly 10 years of software development and system architecture experience. Committed to driving innovation in robust, high-performance systems and empowering teams to deliver impactful solutions. Seeking to leverage deep technical expertise, leadership skills, and microservices best practices to build high-performing development teams, streamline processes, and achieve business objectives in cutting-edge projects.</p>
 <h2>Work Experience</h2>
-<h3>Rust Team Lead @ Inline Group | <a href="https://www.inlinegroup.ru">www.inlinegroup.ru</a></h3>
+<h3>Rust Team Lead @ Inline Group | <a href="https://inlinegroup.ru">inlinegroup.ru</a></h3>
 <p><em>March 2024 – Present  (DURATION)</em></p>
 <ul>
 <li>Led a 12-person backend team (part of a 40+ overall project staff) in an import substitution initiative to migrate business processes from SAP to a custom Rust-based microservices ecosystem.</li>
@@ -114,7 +114,7 @@
 <li>Refactored the codebase for better maintainability, simplifying future feature additions.</li>
 </ul>
 <p><strong>Technologies</strong>: Rust, Exonum, Protocol Buffers, Serde, Git.</p>
-<h3>Rust Developer @ Kryptonite | <a href="https://www.kryptonite.ru">www.kryptonite.ru</a></h3>
+<h3>Rust Developer @ Kryptonite | <a href="https://kryptonite.ru">kryptonite.ru</a></h3>
 <p><em>May 2020 — May 2021 (1 year 1 month)</em></p>
 <ul>
 <li>Migrated a legacy Scala-based voice call processing system to Rust, improving performance and reducing memory usage.</li>
@@ -175,7 +175,7 @@
 <li>Created integration tests for the implemented functionality using Python.</li>
 </ul>
 <p><strong>Technologies</strong>: Myri10GE API, libpcap, PF_RING, C++11, Boost, Python.</p>
-<h3>Middle C++/JS Developer @ LiveTex | <a href="https://www.livetex.ru">www.livetex.ru</a></h3>
+<h3>Middle C++/JS Developer @ LiveTex | <a href="https://livetex.ru">livetex.ru</a></h3>
 <p><em>July 2014 — March 2015 (7 months)</em></p>
 <ul>
 <li>Created wrapper modules for PostgreSQL and ZeroMQ for Node.js.</li>


### PR DESCRIPTION
## Summary
- drop problematic `www` prefixes for Inline Group, Kryptonite, and LiveTex links in the CV and HTML fixture

## Testing
- `bash scripts/repo-setup.sh` *(fails: gh not authenticated)*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `typst compile --root . typst/en/Belyakov_pm_en.typ typst/en/Belyakov_pm_en.pdf`
- `typst compile --root . typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_pm_ru.pdf`
- `cargo test --manifest-path sitegen/Cargo.toml`

Avatar: Automated Test Engineer – chosen to ensure thorough validation of external links and tests.


------
https://chatgpt.com/codex/tasks/task_e_68a3d903cdec83328cb58ff97d1e63d2