### PR TITLE
refactor: simplify English duration formatting

### DIFF
--- a/sitegen/src/renderer.rs
+++ b/sitegen/src/renderer.rs
@@ -6,18 +6,16 @@ pub fn format_duration_en(total_months: i32) -> String {
     let months = total_months % 12;
     let mut parts = Vec::new();
     if years > 0 {
-        if years == 1 {
-            parts.push("1 year".to_string());
-        } else {
-            parts.push(format!("{} years", years));
-        }
+        parts.push(match years {
+            1 => "1 year".to_string(),
+            _ => format!("{years} years"),
+        });
     }
     if months > 0 {
-        if months == 1 {
-            parts.push("1 month".to_string());
-        } else {
-            parts.push(format!("{} months", months));
-        }
+        parts.push(match months {
+            1 => "1 month".to_string(),
+            _ => format!("{months} months"),
+        });
     }
     if parts.is_empty() {
         "0 months".to_string()


### PR DESCRIPTION
## Summary
- simplify English duration formatting with `match`

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml` *(fails: generate command failed)*
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf` *(command not found)*
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf` *(command not found)*

Avatar: DevOps Engineer – задачи связаны с CI/CD и автоматическим деплоем

------
https://chatgpt.com/codex/tasks/task_e_68a66f4d924883329b5ba55eeeb2ce59