### PR TITLE
Add Typst setup script and update agent guide

### DIFF
--- a/REPO_AGENTS.MD
+++ b/REPO_AGENTS.MD
@@ -5,6 +5,11 @@ All source code, documentation, and comments must be in English. Agents must res
 Critically evaluate each user request. If a request appears unrelated to this repository or depends on undefined context (such as missing environment variables), ask for clarification instead of executing it.
 
 Do not edit README.md or README\_RU.md unless the task explicitly requires it.
+Run the repository setup script before starting any task:
+
+```bash
+./repo_setup.sh
+```
 Before running tests or building PDFs, initialize the environment by installing required fonts:
 
 ```bash

--- a/repo_setup.sh
+++ b/repo_setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Typst CLI if it is not already available.
+if ! command -v typst >/dev/null 2>&1; then
+  if ! command -v curl >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y curl
+  fi
+  tmpdir="$(mktemp -d)"
+  curl -L "https://github.com/typst/typst/releases/latest/download/typst-x86_64-unknown-linux-musl.tar.xz" -o "$tmpdir/typst.tar.xz"
+  tar -xf "$tmpdir/typst.tar.xz" -C "$tmpdir"
+  sudo mv "$tmpdir/typst-x86_64-unknown-linux-musl/typst" /usr/local/bin/typst
+  rm -rf "$tmpdir"
+fi


### PR DESCRIPTION
## Summary
- add repo_setup.sh to install Typst CLI
- require agents to run repo_setup.sh before starting tasks

## Testing
- `cargo fmt --all --manifest-path sitegen/Cargo.toml`
- `cargo check --tests --benches --manifest-path sitegen/Cargo.toml`
- `cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings`
- `cargo test --quiet --manifest-path sitegen/Cargo.toml`
- `(cd sitegen && cargo machete)`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68c6f62ea9548332b5dd4abf06b0d829