### PR TITLE
Add HeadHunter resume workflows

### DIFF
--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -1,0 +1,42 @@
+name: hh-publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: prod
+    strategy:
+      matrix:
+        resume:
+          - file: CV_RU.MD
+            id_secret: RESUME_ID_RU
+          - file: CV.MD
+            id_secret: RESUME_ID_EN
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Convert CV to JSON
+        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- ${{ matrix.resume.file }} > resume.json
+
+      - name: Refresh access token
+        run: |
+          curl -X POST https://hh.ru/oauth/token \
+            -d grant_type=refresh_token \
+            -d client_id=${{ secrets.CLIENT_ID }} \
+            -d client_secret=${{ secrets.CLIENT_SECRET }} \
+            -d refresh_token=${{ secrets.REFRESH_TOKEN }} \
+            -o token.json
+          ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
+
+      - name: Upload resume to HH
+        env:
+          RESUME_ID: ${{ secrets[matrix.resume.id_secret] }}
+        run: |
+          curl -X PUT https://api.hh.ru/resumes/$RESUME_ID \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data @resume.json
+

--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -1,12 +1,14 @@
-name: Update HH Resume
+name: hh-update
 
 on:
   push:
     paths:
       - CV_RU.MD
+  schedule:
+    - cron: '0 9 * * *'
 
 jobs:
-  update-hh:
+  update:
     runs-on: ubuntu-latest
     environment: prod
     steps:


### PR DESCRIPTION
## Summary
- schedule HH resume update daily
- add manual workflow to publish resumes to HeadHunter
- normalize workflow naming

## Testing
- `cargo fmt --all` *(fails: could not find `Cargo.toml` in `/workspace/CV` or any parent directory)*
- `cargo check --tests --benches` *(fails: could not find `Cargo.toml` in `/workspace/CV` or any parent directory)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not find `Cargo.toml` in `/workspace/CV` or any parent directory)*
- `cargo test` *(fails: could not find `Cargo.toml` in `/workspace/CV` or any parent directory)*
- `cargo machete`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68c74f553fc483329f0536ae45a11a8d