### PR TITLE
ci: schedule regular HH resume refresh

### DIFF
--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -4,18 +4,26 @@ on:
   push:
     paths:
       - CV_RU.MD
+      - CV.MD
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '10 */4 * * *'
 
 jobs:
   update:
     runs-on: ubuntu-latest
     environment: prod
+    strategy:
+      matrix:
+        resume:
+          - file: CV_RU.MD
+            id_secret: RESUME_ID_RU
+          - file: CV.MD
+            id_secret: RESUME_ID_EN
     steps:
       - uses: actions/checkout@v3
 
       - name: Convert CV to JSON
-        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- CV_RU.MD > resume.json
+        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- ${{ matrix.resume.file }} > resume.json
 
       - name: Refresh access token
         run: |
@@ -30,7 +38,7 @@ jobs:
 
       - name: Upload resume to HH
         env:
-          RESUME_ID: ${{ secrets.RESUME_ID }}
+          RESUME_ID: ${{ secrets[matrix.resume.id_secret] }}
         run: |
           curl -X PUT https://api.hh.ru/resumes/$RESUME_ID \
             -H "Authorization: Bearer $ACCESS_TOKEN" \


### PR DESCRIPTION
## Summary
- refresh both English and Russian resumes on HeadHunter
- run refresh every 4 hours and 10 minutes

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- DevOps Engineer – maintaining and automating CI workflows

------
https://chatgpt.com/codex/tasks/task_e_68c78be7b7908332a7d7bfd41757f8d8