### PR TITLE
Extend HeadHunter workflows for PM resume

### DIFF
--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -12,6 +12,8 @@ jobs:
         resume:
           - file: CV_RU.MD
             id_secret: RESUME_ID_RU
+          - file: CV_PM_RU.MD
+            id_secret: RESUME_ID_PM_RU
           - file: CV.MD
             id_secret: RESUME_ID_EN
     steps:

--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - CV_RU.MD
+      - CV_PM_RU.MD
   schedule:
     - cron: '0 9 * * *'
 
@@ -11,11 +12,18 @@ jobs:
   update:
     runs-on: ubuntu-latest
     environment: prod
+    strategy:
+      matrix:
+        resume:
+          - file: CV_RU.MD
+            id_secret: RESUME_ID_RU
+          - file: CV_PM_RU.MD
+            id_secret: RESUME_ID_PM_RU
     steps:
       - uses: actions/checkout@v3
 
       - name: Convert CV to JSON
-        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- CV_RU.MD > resume.json
+        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- ${{ matrix.resume.file }} > resume.json
 
       - name: Refresh access token
         run: |
@@ -30,7 +38,7 @@ jobs:
 
       - name: Upload resume to HH
         env:
-          RESUME_ID: ${{ secrets.RESUME_ID }}
+          RESUME_ID: ${{ secrets[matrix.resume.id_secret] }}
         run: |
           curl -X PUT https://api.hh.ru/resumes/$RESUME_ID \
             -H "Authorization: Bearer $ACCESS_TOKEN" \


### PR DESCRIPTION
## Summary
- Include project manager Russian resume in HeadHunter publish workflow
- Update hh-update workflow to handle all Russian resumes

## Testing
- `cargo test --manifest-path scripts/convert_cv/Cargo.toml`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: Software Architect — chosen to design CI workflows.


------
https://chatgpt.com/codex/tasks/task_e_68c795d8f940833297512b482df7093b