### PR TITLE
Add PM RU resume to HeadHunter workflows

### DIFF
--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -12,6 +12,8 @@ jobs:
         resume:
           - file: CV_RU.MD
             id_secret: RESUME_ID_RU
+          - file: CV_PM_RU.MD
+            id_secret: RESUME_ID_PM_RU
           - file: CV.MD
             id_secret: RESUME_ID_EN
     steps:

--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - CV_RU.MD
       - CV.MD
+      - CV_PM_RU.MD
   schedule:
     - cron: '10 */4 * * *'
 
@@ -17,6 +18,8 @@ jobs:
         resume:
           - file: CV_RU.MD
             id_secret: RESUME_ID_RU
+          - file: CV_PM_RU.MD
+            id_secret: RESUME_ID_PM_RU
           - file: CV.MD
             id_secret: RESUME_ID_EN
     steps:


### PR DESCRIPTION
## Summary
- add Product Manager Russian CV to hh-update and hh-publish matrices
- monitor PM RU resume changes for HH updates

## Testing
- `cargo check --tests --benches --manifest-path sitegen/Cargo.toml`
- `cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo test --manifest-path scripts/convert_cv/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: devops_maintainer

------
https://chatgpt.com/codex/tasks/task_e_68c7d39606ac8332a49a4c292b816306