### PR TITLE
Refactor HH publishing workflows

### DIFF
--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -2,43 +2,138 @@ name: hh-publish
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Upload payloads to HeadHunter after generating them
+        type: boolean
+        default: false
 
 jobs:
-  publish:
+  generate:
     runs-on: ubuntu-latest
-    environment: prod
-    strategy:
-      matrix:
-        resume:
-          - file: CV_RU.MD
-            id_secret: RESUME_ID_RU
-          - file: CV_PM_RU.MD
-            id_secret: RESUME_ID_PM_RU
-          - file: CV.MD
-            id_secret: RESUME_ID_EN
     steps:
       - uses: actions/checkout@v4
 
-      - name: Convert CV to JSON
-        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- ${{ matrix.resume.file }} > resume.json
+      - name: Generate HH payloads
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p hh_payloads
+          payloads=(
+            "resume_ru:CV_RU.MD"
+            "resume_pm_ru:CV_PM_RU.MD"
+            "resume_en:CV.MD"
+          )
+          for entry in "${payloads[@]}"; do
+            IFS=":" read -r name source <<<"$entry"
+            output="hh_payloads/${name}.json"
+            echo "Rendering ${source} -> ${output}"
+            cargo run --manifest-path scripts/convert_cv/Cargo.toml -- "$source" > "$output"
+          done
+
+      - name: Upload payload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hh-payloads
+          path: hh_payloads
+
+      - name: Summarize generated payloads
+        shell: bash
+        run: |
+          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+            echo "### Generated HeadHunter payloads" >> "$GITHUB_STEP_SUMMARY"
+            ls -1 hh_payloads >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  publish:
+    needs: generate
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download payload artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: hh-payloads
+          path: hh_payloads
 
       - name: Refresh access token
-        run: |
-          curl -X POST https://hh.ru/oauth/token \
-            -d grant_type=refresh_token \
-            -d client_id=${{ secrets.CLIENT_ID }} \
-            -d client_secret=${{ secrets.CLIENT_SECRET }} \
-            -d refresh_token=${{ secrets.REFRESH_TOKEN }} \
-            -o token.json
-          ACCESS_TOKEN=$(jq -r '.access_token' token.json)
-          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
-
-      - name: Upload resume to HH
+        id: token
+        shell: bash
         env:
-          RESUME_ID: ${{ secrets[matrix.resume.id_secret] }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
         run: |
-          curl -X PUT https://api.hh.ru/resumes/$RESUME_ID \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data @resume.json
+          set -euo pipefail
+          response=$(curl -sS -X POST https://hh.ru/oauth/token \
+            -d grant_type=refresh_token \
+            -d client_id="${CLIENT_ID}" \
+            -d client_secret="${CLIENT_SECRET}" \
+            -d refresh_token="${REFRESH_TOKEN}")
+          token=$(echo "$response" | jq -r '.access_token')
+          if [[ -z "$token" || "$token" == "null" ]]; then
+            echo "Unable to extract access token" >&2
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "access_token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Upload resumes to HeadHunter
+        shell: bash
+        env:
+          ACCESS_TOKEN: ${{ steps.token.outputs.access_token }}
+          RESUME_ID_RU: ${{ secrets.RESUME_ID_RU }}
+          RESUME_ID_PM_RU: ${{ secrets.RESUME_ID_PM_RU }}
+          RESUME_ID_EN: ${{ secrets.RESUME_ID_EN }}
+        run: |
+          set -uo pipefail
+          summary_file="${GITHUB_STEP_SUMMARY:-}"
+          if [[ -n "$summary_file" ]]; then
+            echo "### Upload results" >> "$summary_file"
+          fi
+          entries=(
+            "$RESUME_ID_RU:resume_ru.json:Russian resume"
+            "$RESUME_ID_PM_RU:resume_pm_ru.json:Russian PM resume"
+            "$RESUME_ID_EN:resume_en.json:English resume"
+          )
+          status=0
+          for entry in "${entries[@]}"; do
+            IFS=":" read -r resume_id file label <<<"$entry"
+            if [[ -z "$resume_id" ]]; then
+              echo "Skipping ${label}: resume id is not configured" >&2
+              if [[ -n "$summary_file" ]]; then
+                echo "- ⚠️ ${label} (missing RESUME_ID)" >> "$summary_file"
+              fi
+              continue
+            fi
+            payload="hh_payloads/${file}"
+            if [[ ! -f "$payload" ]]; then
+              echo "Payload ${payload} is missing" >&2
+              status=1
+              if [[ -n "$summary_file" ]]; then
+                echo "- ❌ ${label} (payload missing)" >> "$summary_file"
+              fi
+              continue
+            fi
+            echo "Uploading ${label} (${resume_id})"
+            if curl -sS -X PUT "https://api.hh.ru/resumes/${resume_id}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -H "Content-Type: application/json" \
+                --data "@${payload}" \
+                --fail > /dev/null; then
+              if [[ -n "$summary_file" ]]; then
+                echo "- ✅ ${label}" >> "$summary_file"
+              fi
+            else
+              echo "Failed to upload ${label}" >&2
+              status=1
+              if [[ -n "$summary_file" ]]; then
+                echo "- ❌ ${label}" >> "$summary_file"
+              fi
+            fi
+          done
+          exit $status
 

--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -1,49 +1,79 @@
 name: hh-update
 
 on:
-  push:
-    paths:
-      - CV_RU.MD
-      - CV.MD
-      - CV_PM_RU.MD
   schedule:
     - cron: '10 */4 * * *'
+  workflow_dispatch:
 
 jobs:
-  update:
+  promote:
     runs-on: ubuntu-latest
     environment: prod
-    strategy:
-      matrix:
-        resume:
-          - file: CV_RU.MD
-            id_secret: RESUME_ID_RU
-          - file: CV_PM_RU.MD
-            id_secret: RESUME_ID_PM_RU
-          - file: CV.MD
-            id_secret: RESUME_ID_EN
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Convert CV to JSON
-        run: cargo run --manifest-path scripts/convert_cv/Cargo.toml -- ${{ matrix.resume.file }} > resume.json
-
       - name: Refresh access token
-        run: |
-          curl -X POST https://hh.ru/oauth/token \
-            -d grant_type=refresh_token \
-            -d client_id=${{ secrets.CLIENT_ID }} \
-            -d client_secret=${{ secrets.CLIENT_SECRET }} \
-            -d refresh_token=${{ secrets.REFRESH_TOKEN }} \
-            -o token.json
-          ACCESS_TOKEN=$(jq -r '.access_token' token.json)
-          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
-
-      - name: Upload resume to HH
+        id: token
+        shell: bash
         env:
-          RESUME_ID: ${{ secrets[matrix.resume.id_secret] }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
         run: |
-          curl -X PUT https://api.hh.ru/resumes/$RESUME_ID \
-            -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data @resume.json
+          set -euo pipefail
+          response=$(curl -sS -X POST https://hh.ru/oauth/token \
+            -d grant_type=refresh_token \
+            -d client_id="${CLIENT_ID}" \
+            -d client_secret="${CLIENT_SECRET}" \
+            -d refresh_token="${REFRESH_TOKEN}")
+          token=$(echo "$response" | jq -r '.access_token')
+          if [[ -z "$token" || "$token" == "null" ]]; then
+            echo "Unable to extract access token" >&2
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "access_token=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Promote resumes in HeadHunter search
+        shell: bash
+        env:
+          ACCESS_TOKEN: ${{ steps.token.outputs.access_token }}
+          RESUME_ID_RU: ${{ secrets.RESUME_ID_RU }}
+          RESUME_ID_PM_RU: ${{ secrets.RESUME_ID_PM_RU }}
+          RESUME_ID_EN: ${{ secrets.RESUME_ID_EN }}
+        run: |
+          set -uo pipefail
+          summary_file="${GITHUB_STEP_SUMMARY:-}"
+          if [[ -n "$summary_file" ]]; then
+            echo "### Resume promotion results" >> "$summary_file"
+          fi
+          entries=(
+            "$RESUME_ID_RU:Russian resume"
+            "$RESUME_ID_PM_RU:Russian PM resume"
+            "$RESUME_ID_EN:English resume"
+          )
+          status=0
+          for entry in "${entries[@]}"; do
+            IFS=":" read -r resume_id label <<<"$entry"
+            if [[ -z "$resume_id" ]]; then
+              echo "Skipping ${label}: resume id is not configured" >&2
+              if [[ -n "$summary_file" ]]; then
+                echo "- ⚠️ ${label} (missing RESUME_ID)" >> "$summary_file"
+              fi
+              continue
+            fi
+            echo "Promoting ${label} (${resume_id})"
+            if curl -sS -X POST "https://api.hh.ru/resumes/${resume_id}/publish" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -H "Content-Length: 0" \
+                --fail > /dev/null; then
+              if [[ -n "$summary_file" ]]; then
+                echo "- ✅ ${label}" >> "$summary_file"
+              fi
+            else
+              echo "Failed to promote ${label}" >&2
+              status=1
+              if [[ -n "$summary_file" ]]; then
+                echo "- ❌ ${label}" >> "$summary_file"
+              fi
+            fi
+          done
+          exit $status

--- a/scripts/convert_cv/src/main.rs
+++ b/scripts/convert_cv/src/main.rs
@@ -1,5 +1,7 @@
 use pulldown_cmark::{html, Parser};
 use serde::Serialize;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 #[derive(Serialize)]
@@ -14,9 +16,48 @@ fn convert(markdown: &str) -> Resume {
     Resume { body: html_output }
 }
 
+fn repo_root() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .ancestors()
+        .nth(2)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| manifest_dir.to_path_buf())
+}
+
+fn resolve_input(path: &str) -> io::Result<PathBuf> {
+    let candidate = Path::new(path);
+    if candidate.is_absolute() {
+        return Ok(candidate.to_path_buf());
+    }
+
+    if fs::metadata(candidate).is_ok() {
+        return Ok(candidate.to_path_buf());
+    }
+
+    let fallback = repo_root().join(candidate);
+    if fs::metadata(&fallback).is_ok() {
+        Ok(fallback)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "Input file {path} was not found relative to the current directory or repository root (expected at {}).",
+                fallback.display()
+            ),
+        ))
+    }
+}
+
+fn read_markdown(path: &str) -> io::Result<String> {
+    let resolved = resolve_input(path)?;
+    fs::read_to_string(resolved)
+}
+
 fn main() {
     let path = env::args().nth(1).expect("Usage: convert_cv <input.md>");
-    let markdown = fs::read_to_string(path).expect("read input");
+    let markdown = read_markdown(&path)
+        .unwrap_or_else(|err| panic!("Failed to read '{path}'. {err}", path = path, err = err));
     let resume = convert(&markdown);
     serde_json::to_writer(std::io::stdout(), &resume).expect("write json");
 }
@@ -29,5 +70,11 @@ mod tests {
     fn renders_heading() {
         let res = convert("# Title");
         assert_eq!(res.body.trim(), "<h1>Title</h1>");
+    }
+
+    #[test]
+    fn reads_markdown_from_repository_root() {
+        let markdown = read_markdown("CV.MD").expect("read markdown from repository root");
+        assert!(markdown.contains("Alexey"));
     }
 }


### PR DESCRIPTION
## Summary
- Split `hh-publish` into a generation job and an optional upload job that reuses artifacts and hardens token handling. F:.github/workflows/hh-publish.yml#L3-L138
- Rework `hh-update` so it manually or periodically promotes resumes through the HeadHunter publish endpoint instead of rewriting payloads. F:.github/workflows/hh-update.yml#L3-L79
- Let the CV converter resolve markdown paths from the repository root and cover the behavior with a regression test. F:scripts/convert_cv/src/main.rs#L1-L80

## Testing
- `cargo fmt --manifest-path scripts/convert_cv/Cargo.toml`
- `cargo check --tests --benches --manifest-path scripts/convert_cv/Cargo.toml`
- `cargo clippy --all-targets --all-features --manifest-path scripts/convert_cv/Cargo.toml -- -D warnings`
- `cargo test --manifest-path scripts/convert_cv/Cargo.toml`
- `(cd scripts/convert_cv && cargo machete)`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

Avatar: DevOps Engineer — chosen to refactor the HeadHunter automation and harden CI behavior.

------
https://chatgpt.com/codex/tasks/task_e_68c7de50a5008332befe247fa544938c