### PR TITLE
Fix HeadHunter promote workflow token refresh

### DIFF
--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -20,13 +20,18 @@ jobs:
         run: |
           set -euo pipefail
           response=$(curl -sS -X POST https://hh.ru/oauth/token \
-            -d grant_type=refresh_token \
-            -d client_id="${CLIENT_ID}" \
-            -d client_secret="${CLIENT_SECRET}" \
-            -d refresh_token="${REFRESH_TOKEN}")
+            --data-urlencode grant_type=refresh_token \
+            --data-urlencode client_id="${CLIENT_ID}" \
+            --data-urlencode client_secret="${CLIENT_SECRET}" \
+            --data-urlencode refresh_token="${REFRESH_TOKEN}")
           token=$(echo "$response" | jq -r '.access_token')
           if [[ -z "$token" || "$token" == "null" ]]; then
-            echo "Unable to extract access token" >&2
+            message=$(echo "$response" | jq -r '.error_description // .error // empty')
+            if [[ -n "$message" ]]; then
+              echo "HeadHunter OAuth error: ${message}" >&2
+            else
+              echo "Unable to extract access token" >&2
+            fi
             exit 1
           fi
           echo "::add-mask::$token"


### PR DESCRIPTION
## Summary
- URL-encode HeadHunter OAuth parameters to handle secrets with reserved characters and avoid refresh failures 【F:.github/workflows/hh-update.yml#L22-L35】
- Surface HeadHunter error descriptions in the workflow logs when the access token cannot be extracted 【F:.github/workflows/hh-update.yml#L29-L35】

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- DevOps Engineer — расследовал и исправил сбой GitHub Actions при продвижении резюме.


------
https://chatgpt.com/codex/tasks/task_e_68c8be99f0908332ba1e18986d2fbf0e