### PR TITLE
Handle missing resume secrets in hh promotion workflow

### DIFF
--- a/.github/workflows/hh-update.yml
+++ b/.github/workflows/hh-update.yml
@@ -51,9 +51,9 @@ jobs:
             echo "### Resume promotion results" >> "$summary_file"
           fi
           entries=(
-            "$RESUME_ID_RU:Russian resume"
-            "$RESUME_ID_PM_RU:Russian PM resume"
-            "$RESUME_ID_EN:English resume"
+            "${RESUME_ID_RU:-}:Russian resume"
+            "${RESUME_ID_PM_RU:-}:Russian PM resume"
+            "${RESUME_ID_EN:-}:English resume"
           )
           status=0
           for entry in "${entries[@]}"; do


### PR DESCRIPTION
## Summary
- Allow the HeadHunter promotion step to tolerate missing resume IDs by defaulting unset secrets before iterating over the entries. F:.github/workflows/hh-update.yml#L53-L66

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- DevOps Engineer — chosen to diagnose and fix the failing promotion workflow.


------
https://chatgpt.com/codex/tasks/task_e_68c8cf4a02c083328b24e6483aea57b9