### PR TITLE
Rename site release workflow

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -1,4 +1,4 @@
-name: release
+name: release-site
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- rename the GitHub Pages release workflow file to `release-site` to highlight its deployment role
- update the workflow display name to `release-site` for consistency with the new filename

## Testing
- cargo test --manifest-path sitegen/Cargo.toml

## Avatar
- DevOps Engineer — selected to adjust CI/CD workflow naming for clarity

------
https://chatgpt.com/codex/tasks/task_e_68c8e10a550483328775235d6ba020ba