### PR TITLE
Rename setup-cv action directory to build-pdfs

### DIFF
--- a/.github/actions/build-pdfs/action.yml
+++ b/.github/actions/build-pdfs/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Typst and build PDFs'
+name: 'Build Typst PDFs'
 description: 'Install dependencies and build Typst PDFs.'
 runs:
   using: 'composite'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
       - name: Cargo build
         run: cargo build --manifest-path sitegen/Cargo.toml --quiet
       - name: Cargo test

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -29,7 +29,7 @@ jobs:
         id: date
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - if: ${{ inputs.builder == 'typst' }}
-        uses: ./.github/actions/setup-cv
+        uses: ./.github/actions/build-pdfs
       - if: ${{ inputs.builder == 'typst' }}
         name: Prepare Typst release PDFs
         run: |

--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -16,7 +16,7 @@ jobs:
         tool: [qpdf, pdfcpu]
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
 
       - name: Install qpdf
         if: matrix.tool == 'qpdf'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml --quiet
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
       - name: Verify PDFs
         run: |
           for lang in en ru; do


### PR DESCRIPTION
## Summary
- Renamed the composite Typst build action to `.github/actions/build-pdfs` and refreshed its display name. F:.github/actions/build-pdfs/action.yml#L1-L46
- Updated the CI, release, manual PDF, and validation workflows to reference the renamed action. F:.github/workflows/ci.yml#L21-L44 F:.github/workflows/release.yml#L21-L69 F:.github/workflows/pdf-manual.yml#L27-L77 F:.github/workflows/pdf-validate.yml#L18-L63

## Testing
- cargo test --manifest-path sitegen/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

Avatar: Unable to reach avatars.mcp server (received 404 when requesting instructions).

------
https://chatgpt.com/codex/tasks/task_e_68c8e1011d90833291f507697bc68e42