### PR TITLE
Use kebab-case workflow name

### DIFF
--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -1,4 +1,4 @@
-name: pdf validate
+name: pdf-validate
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Set the workflow name to `pdf-validate` to keep workflow identifiers in kebab-case. (F:.github/workflows/pdf-validate.yml#L1)

## Testing
- ✅ `cargo test --manifest-path sitegen/Cargo.toml`
- ✅ `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- ✅ `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- Used DevOps Engineer avatar to handle GitHub Actions naming consistency.


------
https://chatgpt.com/codex/tasks/task_e_68c8e0f758b88332930917134efc5282