### PR TITLE
Rename HeadHunter promotion workflow

### DIFF
--- a/.github/workflows/hh-promote.yml
+++ b/.github/workflows/hh-promote.yml
@@ -1,4 +1,4 @@
-name: hh-update
+name: hh-promote
 
 on:
   schedule:


### PR DESCRIPTION
## Summary
- Rename the HeadHunter promotion workflow file to `hh-promote` and update its displayed name for promotion clarity. F:.github/workflows/hh-promote.yml#L1

## Testing
- cargo test --manifest-path sitegen/Cargo.toml

## Avatar
- Architect avatar – focused on aligning the CI workflow naming with its resume promotion purpose.


------
https://chatgpt.com/codex/tasks/task_e_68c8e0f12a348332ab19cfe9e9f05b2b