### PR TITLE
Rename CI workflow to build-test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: ci
+name: build-test
 
 permissions:
   contents: read

--- a/DOCS/SPECIFICATION.MD
+++ b/DOCS/SPECIFICATION.MD
@@ -33,7 +33,7 @@ This repository implements an automated, multilingual, AI-friendly CV generator 
     ...
   /.github/
     workflows/
-      ci.yml
+      build-test.yml
       release.yml
       pdf-manual.yml
 ```


### PR DESCRIPTION
## Summary
- Rename the CI workflow file to `build-test.yml` and update the workflow display name to match. F:.github/workflows/build-test.yml#L1-L39
- Refresh the repository specification to reference the renamed workflow file. F:DOCS/SPECIFICATION.MD#L20-L38

## Testing
- cargo test --manifest-path sitegen/Cargo.toml 596ee1†L1-L24

## Avatar
- DevOps Engineer — chosen to align CI workflow naming with pipeline clarity and maintainability.


------
https://chatgpt.com/codex/tasks/task_e_68c8e0ed8a488332b424c495a84d8ffa