### PR TITLE
Rename setup composite action to build-pdfs

### DIFF
--- a/.github/actions/build-pdfs/action.yml
+++ b/.github/actions/build-pdfs/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Typst and build PDFs'
+name: 'Build Typst PDFs'
 description: 'Install dependencies and build Typst PDFs.'
 runs:
   using: 'composite'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
       - name: Cargo build
         run: cargo build --manifest-path sitegen/Cargo.toml --quiet
       - name: Cargo test

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -29,7 +29,7 @@ jobs:
         id: date
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - if: ${{ inputs.builder == 'typst' }}
-        uses: ./.github/actions/setup-cv
+        uses: ./.github/actions/build-pdfs
       - if: ${{ inputs.builder == 'typst' }}
         name: Prepare Typst release PDFs
         run: |

--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -16,7 +16,7 @@ jobs:
         tool: [qpdf, pdfcpu]
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
 
       - name: Install qpdf
         if: matrix.tool == 'qpdf'

--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -32,7 +32,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml --quiet
-      - uses: ./.github/actions/setup-cv
+      - uses: ./.github/actions/build-pdfs
       - name: Verify PDFs
         run: |
           for lang in en ru; do


### PR DESCRIPTION
## Summary
- rename the setup-cv composite action directory to build-pdfs and refresh its title
- update CI, PDF, and release workflows to use the renamed composite action

## Testing
- cargo test --manifest-path sitegen/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

## Avatar
- DevOps Engineer — selected to maintain and adjust CI/CD automation artifacts.


------
https://chatgpt.com/codex/tasks/task_e_68c8e8321130833290a8f9f96f0f2cdf