### PR TITLE
Improve HeadHunter workflow secret handling

### DIFF
--- a/.github/workflows/hh-promote.yml
+++ b/.github/workflows/hh-promote.yml
@@ -14,16 +14,44 @@ jobs:
         id: token
         shell: bash
         env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          CLIENT_ID_PRIMARY: ${{ secrets.CLIENT_ID }}
+          CLIENT_ID_FALLBACK: ${{ secrets.HH_CLIENT_ID }}
+          CLIENT_SECRET_PRIMARY: ${{ secrets.CLIENT_SECRET }}
+          CLIENT_SECRET_FALLBACK: ${{ secrets.HH_CLIENT_SECRET }}
+          REFRESH_TOKEN_PRIMARY: ${{ secrets.REFRESH_TOKEN }}
+          REFRESH_TOKEN_FALLBACK: ${{ secrets.HH_REFRESH_TOKEN }}
         run: |
           set -euo pipefail
+
+          client_id="${CLIENT_ID_PRIMARY:-}"
+          if [[ -z "$client_id" ]]; then
+            client_id="${CLIENT_ID_FALLBACK:-}"
+          fi
+
+          client_secret="${CLIENT_SECRET_PRIMARY:-}"
+          if [[ -z "$client_secret" ]]; then
+            client_secret="${CLIENT_SECRET_FALLBACK:-}"
+          fi
+
+          refresh_token="${REFRESH_TOKEN_PRIMARY:-}"
+          if [[ -z "$refresh_token" ]]; then
+            refresh_token="${REFRESH_TOKEN_FALLBACK:-}"
+          fi
+
+          missing=()
+          [[ -z "$client_id" ]] && missing+=("CLIENT_ID or HH_CLIENT_ID")
+          [[ -z "$client_secret" ]] && missing+=("CLIENT_SECRET or HH_CLIENT_SECRET")
+          [[ -z "$refresh_token" ]] && missing+=("REFRESH_TOKEN or HH_REFRESH_TOKEN")
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing secrets: %s\n' "$(IFS=', '; echo "${missing[*]}")" >&2
+            exit 1
+          fi
+
           response=$(curl -sS -X POST https://hh.ru/oauth/token \
             --data-urlencode grant_type=refresh_token \
-            --data-urlencode client_id="${CLIENT_ID}" \
-            --data-urlencode client_secret="${CLIENT_SECRET}" \
-            --data-urlencode refresh_token="${REFRESH_TOKEN}")
+            --data-urlencode client_id="${client_id}" \
+            --data-urlencode client_secret="${client_secret}" \
+            --data-urlencode refresh_token="${refresh_token}")
           token=$(echo "$response" | jq -r '.access_token')
           if [[ -z "$token" || "$token" == "null" ]]; then
             message=$(echo "$response" | jq -r '.error_description // .error // empty')
@@ -41,19 +69,35 @@ jobs:
         shell: bash
         env:
           ACCESS_TOKEN: ${{ steps.token.outputs.access_token }}
-          RESUME_ID_RU: ${{ secrets.RESUME_ID_RU }}
-          RESUME_ID_PM_RU: ${{ secrets.RESUME_ID_PM_RU }}
-          RESUME_ID_EN: ${{ secrets.RESUME_ID_EN }}
+          RESUME_ID_RU_PRIMARY: ${{ secrets.RESUME_ID_RU }}
+          RESUME_ID_RU_FALLBACK: ${{ secrets.HH_RESUME_ID_RU }}
+          RESUME_ID_PM_RU_PRIMARY: ${{ secrets.RESUME_ID_PM_RU }}
+          RESUME_ID_PM_RU_FALLBACK: ${{ secrets.HH_RESUME_ID_PM_RU }}
+          RESUME_ID_EN_PRIMARY: ${{ secrets.RESUME_ID_EN }}
+          RESUME_ID_EN_FALLBACK: ${{ secrets.HH_RESUME_ID_EN }}
         run: |
           set -uo pipefail
+
+          resolve_id() {
+            if [[ -n "$1" ]]; then
+              printf '%s\n' "$1"
+            else
+              printf '%s\n' "$2"
+            fi
+          }
+
+          resume_id_ru=$(resolve_id "${RESUME_ID_RU_PRIMARY:-}" "${RESUME_ID_RU_FALLBACK:-}")
+          resume_id_pm_ru=$(resolve_id "${RESUME_ID_PM_RU_PRIMARY:-}" "${RESUME_ID_PM_RU_FALLBACK:-}")
+          resume_id_en=$(resolve_id "${RESUME_ID_EN_PRIMARY:-}" "${RESUME_ID_EN_FALLBACK:-}")
+
           summary_file="${GITHUB_STEP_SUMMARY:-}"
           if [[ -n "$summary_file" ]]; then
             echo "### Resume promotion results" >> "$summary_file"
           fi
           entries=(
-            "${RESUME_ID_RU:-}:Russian resume"
-            "${RESUME_ID_PM_RU:-}:Russian PM resume"
-            "${RESUME_ID_EN:-}:English resume"
+            "${resume_id_ru}:Russian resume"
+            "${resume_id_pm_ru}:Russian PM resume"
+            "${resume_id_en}:English resume"
           )
           status=0
           for entry in "${entries[@]}"; do

--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -63,19 +63,52 @@ jobs:
         id: token
         shell: bash
         env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          CLIENT_ID_PRIMARY: ${{ secrets.CLIENT_ID }}
+          CLIENT_ID_FALLBACK: ${{ secrets.HH_CLIENT_ID }}
+          CLIENT_SECRET_PRIMARY: ${{ secrets.CLIENT_SECRET }}
+          CLIENT_SECRET_FALLBACK: ${{ secrets.HH_CLIENT_SECRET }}
+          REFRESH_TOKEN_PRIMARY: ${{ secrets.REFRESH_TOKEN }}
+          REFRESH_TOKEN_FALLBACK: ${{ secrets.HH_REFRESH_TOKEN }}
         run: |
           set -euo pipefail
+
+          client_id="${CLIENT_ID_PRIMARY:-}"
+          if [[ -z "$client_id" ]]; then
+            client_id="${CLIENT_ID_FALLBACK:-}"
+          fi
+
+          client_secret="${CLIENT_SECRET_PRIMARY:-}"
+          if [[ -z "$client_secret" ]]; then
+            client_secret="${CLIENT_SECRET_FALLBACK:-}"
+          fi
+
+          refresh_token="${REFRESH_TOKEN_PRIMARY:-}"
+          if [[ -z "$refresh_token" ]]; then
+            refresh_token="${REFRESH_TOKEN_FALLBACK:-}"
+          fi
+
+          missing=()
+          [[ -z "$client_id" ]] && missing+=("CLIENT_ID or HH_CLIENT_ID")
+          [[ -z "$client_secret" ]] && missing+=("CLIENT_SECRET or HH_CLIENT_SECRET")
+          [[ -z "$refresh_token" ]] && missing+=("REFRESH_TOKEN or HH_REFRESH_TOKEN")
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing secrets: %s\n' "$(IFS=', '; echo "${missing[*]}")" >&2
+            exit 1
+          fi
+
           response=$(curl -sS -X POST https://hh.ru/oauth/token \
-            -d grant_type=refresh_token \
-            -d client_id="${CLIENT_ID}" \
-            -d client_secret="${CLIENT_SECRET}" \
-            -d refresh_token="${REFRESH_TOKEN}")
+            --data-urlencode grant_type=refresh_token \
+            --data-urlencode client_id="${client_id}" \
+            --data-urlencode client_secret="${client_secret}" \
+            --data-urlencode refresh_token="${refresh_token}")
           token=$(echo "$response" | jq -r '.access_token')
           if [[ -z "$token" || "$token" == "null" ]]; then
-            echo "Unable to extract access token" >&2
+            message=$(echo "$response" | jq -r '.error_description // .error // empty')
+            if [[ -n "$message" ]]; then
+              echo "HeadHunter OAuth error: ${message}" >&2
+            else
+              echo "Unable to extract access token" >&2
+            fi
             exit 1
           fi
           echo "::add-mask::$token"
@@ -85,19 +118,35 @@ jobs:
         shell: bash
         env:
           ACCESS_TOKEN: ${{ steps.token.outputs.access_token }}
-          RESUME_ID_RU: ${{ secrets.RESUME_ID_RU }}
-          RESUME_ID_PM_RU: ${{ secrets.RESUME_ID_PM_RU }}
-          RESUME_ID_EN: ${{ secrets.RESUME_ID_EN }}
+          RESUME_ID_RU_PRIMARY: ${{ secrets.RESUME_ID_RU }}
+          RESUME_ID_RU_FALLBACK: ${{ secrets.HH_RESUME_ID_RU }}
+          RESUME_ID_PM_RU_PRIMARY: ${{ secrets.RESUME_ID_PM_RU }}
+          RESUME_ID_PM_RU_FALLBACK: ${{ secrets.HH_RESUME_ID_PM_RU }}
+          RESUME_ID_EN_PRIMARY: ${{ secrets.RESUME_ID_EN }}
+          RESUME_ID_EN_FALLBACK: ${{ secrets.HH_RESUME_ID_EN }}
         run: |
           set -uo pipefail
+
+          resolve_id() {
+            if [[ -n "$1" ]]; then
+              printf '%s\n' "$1"
+            else
+              printf '%s\n' "$2"
+            fi
+          }
+
+          resume_id_ru=$(resolve_id "${RESUME_ID_RU_PRIMARY:-}" "${RESUME_ID_RU_FALLBACK:-}")
+          resume_id_pm_ru=$(resolve_id "${RESUME_ID_PM_RU_PRIMARY:-}" "${RESUME_ID_PM_RU_FALLBACK:-}")
+          resume_id_en=$(resolve_id "${RESUME_ID_EN_PRIMARY:-}" "${RESUME_ID_EN_FALLBACK:-}")
+
           summary_file="${GITHUB_STEP_SUMMARY:-}"
           if [[ -n "$summary_file" ]]; then
             echo "### Upload results" >> "$summary_file"
           fi
           entries=(
-            "$RESUME_ID_RU:resume_ru.json:Russian resume"
-            "$RESUME_ID_PM_RU:resume_pm_ru.json:Russian PM resume"
-            "$RESUME_ID_EN:resume_en.json:English resume"
+            "$resume_id_ru:resume_ru.json:Russian resume"
+            "$resume_id_pm_ru:resume_pm_ru.json:Russian PM resume"
+            "$resume_id_en:resume_en.json:English resume"
           )
           status=0
           for entry in "${entries[@]}"; do


### PR DESCRIPTION
## Summary
- add fallback resolution for HeadHunter OAuth secrets and resume identifiers in the hh-promote workflow
- improve hh-publish token refresh to match the same fallbacks and propagate clearer failures
- keep both workflows informative when configuration is missing

## Testing
- cargo test --manifest-path sitegen/Cargo.toml

## Notes
- Unable to fetch avatar instructions: https://qqrm.github.io/avatars-mcp/ returned 404.


------
https://chatgpt.com/codex/tasks/task_e_68ca90ff4d0083329be9a558e2ad18f1