### PR TITLE
Ensure local setup configures origin remote

### DIFF
--- a/local_setup.sh
+++ b/local_setup.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configure git remotes so local operations mirror the upstream repository.
+REPO_ROOT="${SCRIPT_DIR}"
+ORIGIN_URL="https://github.com/qqrm/CV.git"
+if ! git -C "${REPO_ROOT}" remote get-url origin >/dev/null 2>&1; then
+  git -C "${REPO_ROOT}" remote add origin "${ORIGIN_URL}"
+elif [[ "$(git -C "${REPO_ROOT}" remote get-url origin)" != "${ORIGIN_URL}" ]]; then
+  git -C "${REPO_ROOT}" remote set-url origin "${ORIGIN_URL}"
+fi
+
 # Install fonts required for Typst templates.
 if ! fc-list | grep -qi "Latin Modern Roman"; then
   sudo apt-get update


### PR DESCRIPTION
## Summary
- configure `local_setup.sh` to enforce the `origin` remote URL for the CV repository so tooling can access CI logs (F:local_setup.sh#L4-L13)

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`

## Avatar
- Avatar: DevOps Engineer — updating local automation for CI visibility.


------
https://chatgpt.com/codex/tasks/task_e_68cab91a02a08332810ba38cd1fbcad3