### PR TITLE
chore: harmonize workflow names

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: build-test
+name: CI: Build & Test
 
 permissions:
   contents: read

--- a/.github/workflows/hh-promote.yml
+++ b/.github/workflows/hh-promote.yml
@@ -1,4 +1,4 @@
-name: hh-promote
+name: HeadHunter: Promote
 
 on:
   schedule:

--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -1,4 +1,4 @@
-name: hh-publish
+name: HeadHunter: Publish
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -1,4 +1,4 @@
-name: pdf-manual
+name: PDF: Manual Build
 
 permissions:
   contents: read

--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -1,4 +1,4 @@
-name: pdf-validate
+name: PDF: Validate
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -1,4 +1,4 @@
-name: release-site
+name: Website: Release
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Rename the CI workflow to "CI: Build & Test" and the website release pipeline to "Website: Release" for consistent prefixes. F:.github/workflows/build-test.yml#L1-L19 F:.github/workflows/release-site.yml#L1-L20
- Align HeadHunter and PDF workflow titles under the shared naming scheme. F:.github/workflows/hh-promote.yml#L1-L20 F:.github/workflows/hh-publish.yml#L1-L20 F:.github/workflows/pdf-manual.yml#L1-L19 F:.github/workflows/pdf-validate.yml#L1-L19
- Avatar: DevOps Engineer – chosen to normalize CI/CD naming conventions across workflows.

## Testing
- cargo test --manifest-path sitegen/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68cae7ffa22c83328b400df75672bfd8