### PR TITLE
Organize CV and resume markdown into profiles directories

### DIFF
--- a/BACKLOG/TASKS/LANGUAGE_POLICY.MD
+++ b/BACKLOG/TASKS/LANGUAGE_POLICY.MD
@@ -1,12 +1,12 @@
 # Task: Clarify documentation language policy
 
 ## Description
-The `AGENTS.MD` states that all documentation is maintained in English, but the repository contains Russian files such as `README_RU.MD`, `CV_RU.MD` and `DOCS/ru/`. Update the guidelines to explicitly mention allowed localized documents or translate remaining Russian files to English.
+The `AGENTS.MD` states that all documentation is maintained in English, but the repository contains Russian files such as `README_RU.MD`, `profiles/cv/ru/CV_RU.MD` and `DOCS/ru/`. Update the guidelines to explicitly mention allowed localized documents or translate remaining Russian files to English.
 
 ## Related files
 - AGENTS.MD
 - README_RU.MD
-- CV_RU.MD
+- profiles/cv/ru/CV_RU.MD
 - DOCS/ru/
 - ROADMAPMD.MD
 

--- a/BACKLOG/TASKS/UPPERCASE_CV_FILES.MD
+++ b/BACKLOG/TASKS/UPPERCASE_CV_FILES.MD
@@ -1,11 +1,11 @@
 # Task: Rename CV markdown files to uppercase
 
 ## Description
-The repository guidelines require all Markdown filenames to use uppercase letters. Ensure `CV.MD` and `CV_RU.MD` follow this rule and update references in documentation and build scripts where necessary.
+The repository guidelines require all Markdown filenames to use uppercase letters. Ensure `profiles/cv/en/CV.MD` and `profiles/cv/ru/CV_RU.MD` follow this rule and update references in documentation and build scripts where necessary.
 
 ## Related files
-- CV.MD
-- CV_RU.MD
+- profiles/cv/en/CV.MD
+- profiles/cv/ru/CV_RU.MD
 - sitegen/src/*
 - README.MD and README_RU.MD
 

--- a/DOCS/SPECIFICATION.MD
+++ b/DOCS/SPECIFICATION.MD
@@ -6,7 +6,7 @@
 
 This repository implements an automated, multilingual, AI-friendly CV generator and publisher, featuring:
 
-- Centralized markdown sources for career information (`CV.MD`, `CV_RU.MD`).
+- Centralized markdown sources for career information (`profiles/cv/en/CV.MD`, `profiles/cv/ru/CV_RU.MD`).
 - A TOML file listing target roles with short codes and full titles (`roles.toml`).
 - A Typst template for generating PDF CVs (`/template/base.typ`).
 - A Rust application for parsing, validating, and generating all artifacts.
@@ -18,8 +18,13 @@ This repository implements an automated, multilingual, AI-friendly CV generator 
 
 ```
 /
-  CV.MD
-  CV_RU.MD
+  profiles/
+    cv/
+      en/CV.MD
+      ru/CV_RU.MD
+    resume/
+      en/RESUME_TL.MD
+      ru/RESUME_TL_RU.MD
   roles.toml
   /template/
     base.typ

--- a/README.MD
+++ b/README.MD
@@ -3,8 +3,8 @@
 This repository contains the source files for my CV. The Markdown versions are
 automatically converted into PDFs and a static website.
 
-- [English CV](./CV.MD)
-- [Russian CV](./CV_RU.MD)
+- [English CV](./profiles/cv/en/CV.MD)
+- [Russian CV](./profiles/cv/ru/CV_RU.MD)
 - [PDF (en)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
 - [PDF (ru)](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
 - [Web version (en)](https://qqrm.github.io/CV/)

--- a/README_RU.MD
+++ b/README_RU.MD
@@ -4,8 +4,8 @@
 
 Репозиторий содержит исходные файлы моего резюме. Markdown-файлы преобразуются в PDF и веб-страницы.
 
-- [CV на английском](./CV.MD)
-- [Русская версия CV](./CV_RU.MD)
+- [CV на английском](./profiles/cv/en/CV.MD)
+- [Русская версия CV](./profiles/cv/ru/CV_RU.MD)
 - [PDF на английском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_en_typst.pdf)
 - [PDF на русском](https://github.com/qqrm/CV/releases/latest/download/Belyakov_ru_typst.pdf)
 - [Сайт](https://qqrm.github.io/CV/)

--- a/SPEC.MD
+++ b/SPEC.MD
@@ -6,9 +6,9 @@
 - Provide reusable tooling (Rust + Typst) to validate content, build pages, and keep outputs synchronized with the Markdown data.
 
 ## 2. Authoritative Content Sources
-- `CV.MD`, `CV_RU.MD` — primary CV narratives in English and Russian.
-- `CV_PM.MD`, `CV_PM_RU.MD` — dedicated product manager resume content for both languages.
-- `RESUME_TL.MD`, `RESUME_EM.MD`, `RESUME_HOD.MD`, `RESUME_PM.MD`, `RESUME_TECH.MD` plus their `_RU` counterparts — role-focused highlights consumed by Typst and site generation.
+- `profiles/cv/en/CV.MD`, `profiles/cv/ru/CV_RU.MD` — primary CV narratives in English and Russian.
+- `profiles/cv/en/CV_PM.MD`, `profiles/cv/ru/CV_PM_RU.MD` — dedicated product manager resume content for both languages.
+- `profiles/resume/en/RESUME_TL.MD`, `profiles/resume/en/RESUME_EM.MD`, `profiles/resume/en/RESUME_HOD.MD`, `profiles/resume/en/RESUME_PM.MD`, `profiles/resume/en/RESUME_TECH.MD` plus their `_RU` counterparts under `profiles/resume/ru/` — role-focused highlights consumed by Typst and site generation.
 - `roles.toml` — maps role slugs to human-readable titles used for role-specific pages and PDFs. Every role listed here has a dedicated Markdown resume variant and Typst template to generate tailored deliverables.
 - `/content/avatar.jpg` plus `/DOCS/style.css` and `/DOCS/favicon.svg` — shared visual assets for PDFs and the static site.
 
@@ -20,7 +20,7 @@
 ## 4. Rust Tooling
 - `sitegen` crate (`sitegen/Cargo.toml`) centralizes parsing and rendering logic.
   - Library modules:
-    - `parser.rs` parses month names, extracts inline employment start dates from `CV.MD`, and loads `roles.toml` with validation.
+    - `parser.rs` parses month names, extracts inline employment start dates from `profiles/cv/en/CV.MD`, and loads `roles.toml` with validation.
     - `renderer.rs` formats experience durations for English and Russian output.
   - Binaries:
     - `validate` ensures Markdown files and `roles.toml` exist and are syntactically correct.
@@ -51,7 +51,13 @@
 ├── sitegen/              # Main Rust crate with generate/validate binaries and templates
 ├── TASKS/, BACKLOG/      # Planning and roadmap documents
 ├── typst/                # Typst sources for EN/RU PDFs
-└── *.MD                  # Markdown CV sources and guidance documents
+└── profiles/             # Localized CV and resume Markdown sources
+    ├── cv/
+    │   ├── en/           # English narratives (CV.MD, CV_PM.MD, ...)
+    │   └── ru/           # Russian narratives (CV_RU.MD, CV_PM_RU.MD, ...)
+    └── resume/
+        ├── en/          # English resume variants (RESUME_TL.MD, ...)
+        └── ru/          # Russian resume variants (RESUME_TL_RU.MD, ...)
 ```
 
 ## 8. Outputs and Deployment Targets

--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -1,5 +1,5 @@
 # Alexey Leonidovich Belyakov
-*[Link to russian version](./CV_RU.MD)* \\
+*[Link to russian version](../ru/CV_RU.MD)* \\
 *[Link to PDF](https://qqrm.github.io/CV/Belyakov_en.pdf)* \\
 *[Link to russian PDF](https://qqrm.github.io/CV/Belyakov_ru.pdf)*
 

--- a/profiles/cv/en/CV_EM.MD
+++ b/profiles/cv/en/CV_EM.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./CV_EM_RU.MD)* \\
+*[Link to Russian version](../ru/CV_EM_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_em_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru.pdf)*
 

--- a/profiles/cv/en/CV_HOD.MD
+++ b/profiles/cv/en/CV_HOD.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./CV_HOD_RU.MD)* \\
+*[Link to Russian version](../ru/CV_HOD_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_hod_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_hod_ru.pdf)*
 

--- a/profiles/cv/en/CV_PM.MD
+++ b/profiles/cv/en/CV_PM.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./CV_PM_RU.MD)* \\
+*[Link to Russian version](../ru/CV_PM_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_pm_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_pm_ru.pdf)*
 

--- a/profiles/cv/en/CV_TECH.MD
+++ b/profiles/cv/en/CV_TECH.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./CV_TECH_RU.MD)* \\
+*[Link to Russian version](../ru/CV_TECH_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_tech_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_tech_ru.pdf)*
 

--- a/profiles/cv/en/CV_TL.MD
+++ b/profiles/cv/en/CV_TL.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./CV_TL_RU.MD)* \\
+*[Link to Russian version](../ru/CV_TL_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_tl_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_tl_ru.pdf)*
 

--- a/profiles/cv/ru/CV_EM_RU.MD
+++ b/profiles/cv/ru/CV_EM_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./CV_EM.MD)* \\
+*[Ссылка на английскую версию](../en/CV_EM.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_em_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_em_en.pdf)*
 

--- a/profiles/cv/ru/CV_HOD_RU.MD
+++ b/profiles/cv/ru/CV_HOD_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./CV_HOD.MD)* \\
+*[Ссылка на английскую версию](../en/CV_HOD.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_hod_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_hod_en.pdf)*
 

--- a/profiles/cv/ru/CV_PM_RU.MD
+++ b/profiles/cv/ru/CV_PM_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./CV_PM.MD)* \\
+*[Ссылка на английскую версию](../en/CV_PM.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_pm_ru.pdf)* \\
 *[Download PDF (EN)](https://qqrm.github.io/CV/Belyakov_pm_en.pdf)*
 

--- a/profiles/cv/ru/CV_RU.MD
+++ b/profiles/cv/ru/CV_RU.MD
@@ -1,5 +1,5 @@
 # Алексей Леонидович Беляков
-*[Ссылка на английскую версию](./CV.MD)* \\
+*[Ссылка на английскую версию](../en/CV.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_ru.pdf)* \\
 *[Download PDF (EN)](https://qqrm.github.io/CV/Belyakov_en.pdf)*
 

--- a/profiles/cv/ru/CV_TECH_RU.MD
+++ b/profiles/cv/ru/CV_TECH_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./CV_TECH.MD)* \\
+*[Ссылка на английскую версию](../en/CV_TECH.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_tech_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_tech_en.pdf)*
 

--- a/profiles/cv/ru/CV_TL_RU.MD
+++ b/profiles/cv/ru/CV_TL_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./CV_TL.MD)* \\
+*[Ссылка на английскую версию](../en/CV_TL.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_tl_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_tl_en.pdf)*
 

--- a/profiles/resume/en/RESUME_EM.MD
+++ b/profiles/resume/en/RESUME_EM.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./RESUME_EM_RU.MD)* \\
+*[Link to Russian version](../ru/RESUME_EM_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_em_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru.pdf)*
 

--- a/profiles/resume/en/RESUME_HOD.MD
+++ b/profiles/resume/en/RESUME_HOD.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./RESUME_HOD_RU.MD)* \\
+*[Link to Russian version](../ru/RESUME_HOD_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_hod_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_hod_ru.pdf)*
 

--- a/profiles/resume/en/RESUME_PM.MD
+++ b/profiles/resume/en/RESUME_PM.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./RESUME_PM_RU.MD)* \\
+*[Link to Russian version](../ru/RESUME_PM_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_pm_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_pm_ru.pdf)*
 

--- a/profiles/resume/en/RESUME_TECH.MD
+++ b/profiles/resume/en/RESUME_TECH.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./RESUME_TECH_RU.MD)* \\
+*[Link to Russian version](../ru/RESUME_TECH_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_tech_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_tech_ru.pdf)*
 

--- a/profiles/resume/en/RESUME_TL.MD
+++ b/profiles/resume/en/RESUME_TL.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Link to Russian version](./RESUME_TL_RU.MD)* \\
+*[Link to Russian version](../ru/RESUME_TL_RU.MD)* \\
 *[Download PDF](https://qqrm.github.io/CV/Belyakov_tl_en.pdf)* \\
 *[Download Russian PDF](https://qqrm.github.io/CV/Belyakov_tl_ru.pdf)*
 

--- a/profiles/resume/ru/RESUME_EM_RU.MD
+++ b/profiles/resume/ru/RESUME_EM_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./RESUME_EM.MD)* \\
+*[Ссылка на английскую версию](../en/RESUME_EM.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_em_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_em_en.pdf)*
 

--- a/profiles/resume/ru/RESUME_HOD_RU.MD
+++ b/profiles/resume/ru/RESUME_HOD_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./RESUME_HOD.MD)* \\
+*[Ссылка на английскую версию](../en/RESUME_HOD.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_hod_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_hod_en.pdf)*
 

--- a/profiles/resume/ru/RESUME_PM_RU.MD
+++ b/profiles/resume/ru/RESUME_PM_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./RESUME_PM.MD)* \\
+*[Ссылка на английскую версию](../en/RESUME_PM.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_pm_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_pm_en.pdf)*
 

--- a/profiles/resume/ru/RESUME_TECH_RU.MD
+++ b/profiles/resume/ru/RESUME_TECH_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./RESUME_TECH.MD)* \\
+*[Ссылка на английскую версию](../en/RESUME_TECH.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_tech_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_tech_en.pdf)*
 

--- a/profiles/resume/ru/RESUME_TL_RU.MD
+++ b/profiles/resume/ru/RESUME_TL_RU.MD
@@ -1,5 +1,5 @@
 # {NAME}
-*[Ссылка на английскую версию](./RESUME_TL.MD)* \\
+*[Ссылка на английскую версию](../en/RESUME_TL.MD)* \\
 *[Скачать PDF](https://qqrm.github.io/CV/Belyakov_tl_ru.pdf)* \\
 *[Скачать PDF (EN)](https://qqrm.github.io/CV/Belyakov_tl_en.pdf)*
 

--- a/scripts/convert_cv/src/main.rs
+++ b/scripts/convert_cv/src/main.rs
@@ -74,7 +74,8 @@ mod tests {
 
     #[test]
     fn reads_markdown_from_repository_root() {
-        let markdown = read_markdown("CV.MD").expect("read markdown from repository root");
+        let markdown =
+            read_markdown("profiles/cv/en/CV.MD").expect("read markdown from repository root");
         assert!(markdown.contains("Alexey"));
     }
 }

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -100,11 +100,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let pdf_typst_en_ru = "../Belyakov_en.pdf";
     let pdf_typst_ru_ru = "../Belyakov_ru.pdf";
 
-    let markdown_input = fs::read_to_string("CV.MD")?;
+    let markdown_input = fs::read_to_string("profiles/cv/en/CV.MD")?;
     let parser = CmarkParser::new_ext(&markdown_input, Options::all());
     let mut html_body_en = String::new();
     push_html(&mut html_body_en, parser);
-    html_body_en = html_body_en.replace("./CV_RU.MD", "ru/");
+    html_body_en = html_body_en.replace("../ru/CV_RU.MD", "ru/");
     html_body_en = html_body_en.replace("https://qqrm.github.io/CV/Belyakov_en.pdf", pdf_typst_en);
     html_body_en = html_body_en.replace("https://qqrm.github.io/CV/Belyakov_ru.pdf", pdf_typst_ru);
     html_body_en = html_body_en.replace(
@@ -115,11 +115,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         html_body_en = html_body_en[end + 5..].trim_start().to_string();
     }
 
-    let markdown_ru = fs::read_to_string("CV_RU.MD")?;
+    let markdown_ru = fs::read_to_string("profiles/cv/ru/CV_RU.MD")?;
     let parser_ru = CmarkParser::new_ext(&markdown_ru, Options::all());
     let mut html_body_ru = String::new();
     push_html(&mut html_body_ru, parser_ru);
-    html_body_ru = html_body_ru.replace("./CV.MD", "../");
+    html_body_ru = html_body_ru.replace("../en/CV.MD", "../");
     html_body_ru =
         html_body_ru.replace("https://qqrm.github.io/CV/Belyakov_ru.pdf", pdf_typst_ru_ru);
     html_body_ru =
@@ -137,11 +137,31 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Prepare role-specific resume bodies
     let resume_specs = [
-        ("tl", "RESUME_TL.MD", "RESUME_TL_RU.MD"),
-        ("em", "RESUME_EM.MD", "RESUME_EM_RU.MD"),
-        ("hod", "RESUME_HOD.MD", "RESUME_HOD_RU.MD"),
-        ("pm", "RESUME_PM.MD", "RESUME_PM_RU.MD"),
-        ("tech", "RESUME_TECH.MD", "RESUME_TECH_RU.MD"),
+        (
+            "tl",
+            "profiles/resume/en/RESUME_TL.MD",
+            "profiles/resume/ru/RESUME_TL_RU.MD",
+        ),
+        (
+            "em",
+            "profiles/resume/en/RESUME_EM.MD",
+            "profiles/resume/ru/RESUME_EM_RU.MD",
+        ),
+        (
+            "hod",
+            "profiles/resume/en/RESUME_HOD.MD",
+            "profiles/resume/ru/RESUME_HOD_RU.MD",
+        ),
+        (
+            "pm",
+            "profiles/resume/en/RESUME_PM.MD",
+            "profiles/resume/ru/RESUME_PM_RU.MD",
+        ),
+        (
+            "tech",
+            "profiles/resume/en/RESUME_TECH.MD",
+            "profiles/resume/ru/RESUME_TECH_RU.MD",
+        ),
     ];
     let mut resume_contents: Vec<(String, ResumeContent)> = Vec::new();
     for (slug, en_md, ru_md) in resume_specs {
@@ -150,7 +170,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let parser_resume_en = CmarkParser::new_ext(&markdown_resume_en, Options::all());
         let mut html_resume_en = String::new();
         push_html(&mut html_resume_en, parser_resume_en);
-        let link_to_ru = format!("./RESUME_{}_RU.MD", slug_upper);
+        let link_to_ru = format!("../ru/RESUME_{}_RU.MD", slug_upper);
         html_resume_en = html_resume_en.replace(&link_to_ru, "ru/");
         if let Some(end) = html_resume_en.find("</h1>") {
             html_resume_en = html_resume_en[end + 5..].trim_start().to_string();
@@ -160,7 +180,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let parser_resume_ru = CmarkParser::new_ext(&markdown_resume_ru, Options::all());
         let mut html_resume_ru = String::new();
         push_html(&mut html_resume_ru, parser_resume_ru);
-        let link_to_en = format!("./RESUME_{}.MD", slug_upper);
+        let link_to_en = format!("../en/RESUME_{}.MD", slug_upper);
         html_resume_ru = html_resume_ru.replace(&link_to_en, "../");
         if let Some(end) = html_resume_ru.find("</h1>") {
             html_resume_ru = html_resume_ru[end + 5..].trim_start().to_string();

--- a/sitegen/src/bin/validate.rs
+++ b/sitegen/src/bin/validate.rs
@@ -6,8 +6,8 @@ use std::fs;
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     info!("Starting validation");
-    fs::read_to_string("CV.MD")?;
-    fs::read_to_string("CV_RU.MD")?;
+    fs::read_to_string("profiles/cv/en/CV.MD")?;
+    fs::read_to_string("profiles/cv/ru/CV_RU.MD")?;
     fs::read_to_string("roles.toml")?;
     read_roles()?;
     info!("Validation successful");

--- a/sitegen/src/parser.rs
+++ b/sitegen/src/parser.rs
@@ -6,6 +6,8 @@ use std::fmt;
 use std::fs;
 use std::io;
 
+const CV_EN_PATH: &str = "profiles/cv/en/CV.MD";
+
 #[derive(Debug)]
 pub enum InlineStartError {
     Io(io::Error),
@@ -15,7 +17,7 @@ pub enum InlineStartError {
 impl fmt::Display for InlineStartError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            InlineStartError::Io(_) => write!(f, "failed to read CV.MD"),
+            InlineStartError::Io(_) => write!(f, "failed to read {CV_EN_PATH}"),
             InlineStartError::Parse => write!(f, "could not parse inline start"),
         }
     }
@@ -84,15 +86,16 @@ pub fn month_from_ru(name: &str) -> Option<u32> {
 
 /// Read the starting month and year of the most recent CV entry.
 ///
-/// The function expects a `CV.MD` file in the current directory and
+/// The function expects the English CV Markdown at
+/// `profiles/cv/en/CV.MD` and
 /// looks for a list item starting with the month and year followed by
 /// an en dash or em dash and the word "Present" (English) or
 /// "Настоящее время" (Russian).
 ///
 /// Returns a pair `(year, month)` on success.
 pub fn read_inline_start() -> Result<(i32, u32), InlineStartError> {
-    debug!("Scanning CV.MD for inline start");
-    let content = std::fs::read_to_string("CV.MD")?;
+    debug!("Scanning {CV_EN_PATH} for inline start");
+    let content = std::fs::read_to_string(CV_EN_PATH)?;
     for line in content.lines() {
         if let Some((month_str, year_str)) = line
             .trim()
@@ -121,7 +124,7 @@ pub fn read_inline_start() -> Result<(i32, u32), InlineStartError> {
             }
         }
     }
-    warn!("Failed to parse inline start from CV.MD");
+    warn!("Failed to parse inline start from {CV_EN_PATH}");
     Err(InlineStartError::Parse)
 }
 

--- a/sitegen/tests/inline_start.rs
+++ b/sitegen/tests/inline_start.rs
@@ -8,7 +8,8 @@ fn reads_inline_start_from_markdown() {
     let dir = tempfile::tempdir().expect("temp dir");
     let original = env::current_dir().unwrap();
     env::set_current_dir(dir.path()).unwrap();
-    fs::write("CV.MD", "* March 2024 – Present").unwrap();
+    fs::create_dir_all("profiles/cv/en").unwrap();
+    fs::write("profiles/cv/en/CV.MD", "* March 2024 – Present").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
     assert_eq!(result.unwrap(), (2024, 3));
@@ -20,7 +21,8 @@ fn read_inline_start_returns_error_for_invalid_file() {
     let dir = tempfile::tempdir().expect("temp dir");
     let original = env::current_dir().unwrap();
     env::set_current_dir(dir.path()).unwrap();
-    fs::write("CV.MD", "* Not a valid entry").unwrap();
+    fs::create_dir_all("profiles/cv/en").unwrap();
+    fs::write("profiles/cv/en/CV.MD", "* Not a valid entry").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
     let err = result.expect_err("expected parse error");
@@ -34,7 +36,8 @@ fn read_inline_start_returns_error_for_invalid_month() {
     let dir = tempfile::tempdir().expect("temp dir");
     let original = env::current_dir().unwrap();
     env::set_current_dir(dir.path()).unwrap();
-    fs::write("CV.MD", "* Smarch 2024 – Present").unwrap();
+    fs::create_dir_all("profiles/cv/en").unwrap();
+    fs::write("profiles/cv/en/CV.MD", "* Smarch 2024 – Present").unwrap();
     let result = read_inline_start();
     env::set_current_dir(original).unwrap();
     let err = result.expect_err("expected parse error");
@@ -52,5 +55,5 @@ fn read_inline_start_returns_error_when_file_missing() {
     env::set_current_dir(original).unwrap();
     let err = result.expect_err("expected io error");
     assert!(matches!(err, InlineStartError::Io(_)));
-    assert_eq!(err.to_string(), "failed to read CV.MD");
+    assert_eq!(err.to_string(), "failed to read profiles/cv/en/CV.MD");
 }

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -25,24 +25,24 @@
     )
     #let resume_paths = (
       "tl": (
-        en: "../RESUME_TL.MD",
-        ru: "../RESUME_TL_RU.MD",
+        en: "../profiles/resume/en/RESUME_TL.MD",
+        ru: "../profiles/resume/ru/RESUME_TL_RU.MD",
       ),
       "em": (
-        en: "../RESUME_EM.MD",
-        ru: "../RESUME_EM_RU.MD",
+        en: "../profiles/resume/en/RESUME_EM.MD",
+        ru: "../profiles/resume/ru/RESUME_EM_RU.MD",
       ),
       "hod": (
-        en: "../RESUME_HOD.MD",
-        ru: "../RESUME_HOD_RU.MD",
+        en: "../profiles/resume/en/RESUME_HOD.MD",
+        ru: "../profiles/resume/ru/RESUME_HOD_RU.MD",
       ),
       "pm": (
-        en: "../RESUME_PM.MD",
-        ru: "../RESUME_PM_RU.MD",
+        en: "../profiles/resume/en/RESUME_PM.MD",
+        ru: "../profiles/resume/ru/RESUME_PM_RU.MD",
       ),
       "tech": (
-        en: "../RESUME_TECH.MD",
-        ru: "../RESUME_TECH_RU.MD",
+        en: "../profiles/resume/en/RESUME_TECH.MD",
+        ru: "../profiles/resume/ru/RESUME_TECH_RU.MD",
       ),
     )
     #let base = "https://qqrm.github.io/CV/"
@@ -62,9 +62,9 @@
         if using_resume {
           if lang == "ru" { resume_entry.at("ru") } else { resume_entry.at("en") }
         } else if lang == "ru" {
-          "../CV_RU.MD"
+          "../profiles/cv/ru/CV_RU.MD"
         } else {
-          "../CV.MD"
+          "../profiles/cv/en/CV.MD"
         }
       } else {
         md_path

--- a/typst/en/Belyakov_em_en.typ
+++ b/typst/en/Belyakov_em_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Engineering Manager", md_path: "../CV_EM.MD")
+#resume(lang: "en", role: "Engineering Manager", md_path: "../../profiles/cv/en/CV_EM.MD")

--- a/typst/en/Belyakov_hod_en.typ
+++ b/typst/en/Belyakov_hod_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Head of Development", md_path: "../CV_HOD.MD")
+#resume(lang: "en", role: "Head of Development", md_path: "../../profiles/cv/en/CV_HOD.MD")

--- a/typst/en/Belyakov_pm_en.typ
+++ b/typst/en/Belyakov_pm_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Product Manager", md_path: "../CV_PM.MD")
+#resume(lang: "en", role: "Product Manager", md_path: "../../profiles/cv/en/CV_PM.MD")

--- a/typst/en/Belyakov_tech_en.typ
+++ b/typst/en/Belyakov_tech_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Tech Lead", md_path: "../CV_TECH.MD")
+#resume(lang: "en", role: "Tech Lead", md_path: "../../profiles/cv/en/CV_TECH.MD")

--- a/typst/en/Belyakov_tl_en.typ
+++ b/typst/en/Belyakov_tl_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Team Lead", md_path: "../CV_TL.MD")
+#resume(lang: "en", role: "Team Lead", md_path: "../../profiles/cv/en/CV_TL.MD")

--- a/typst/ru/Belyakov_em_ru.typ
+++ b/typst/ru/Belyakov_em_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Engineering Manager", md_path: "../CV_EM_RU.MD")
+#resume(lang: "ru", role: "Engineering Manager", md_path: "../../profiles/cv/ru/CV_EM_RU.MD")

--- a/typst/ru/Belyakov_hod_ru.typ
+++ b/typst/ru/Belyakov_hod_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Head of Development", md_path: "../CV_HOD_RU.MD")
+#resume(lang: "ru", role: "Head of Development", md_path: "../../profiles/cv/ru/CV_HOD_RU.MD")

--- a/typst/ru/Belyakov_pm_ru.typ
+++ b/typst/ru/Belyakov_pm_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Product Manager", md_path: "../CV_PM_RU.MD")
+#resume(lang: "ru", role: "Product Manager", md_path: "../../profiles/cv/ru/CV_PM_RU.MD")

--- a/typst/ru/Belyakov_tech_ru.typ
+++ b/typst/ru/Belyakov_tech_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Tech Lead", md_path: "../CV_TECH_RU.MD")
+#resume(lang: "ru", role: "Tech Lead", md_path: "../../profiles/cv/ru/CV_TECH_RU.MD")

--- a/typst/ru/Belyakov_tl_ru.typ
+++ b/typst/ru/Belyakov_tl_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Team Lead", md_path: "../CV_TL_RU.MD")
+#resume(lang: "ru", role: "Team Lead", md_path: "../../profiles/cv/ru/CV_TL_RU.MD")


### PR DESCRIPTION
## Summary
- move CV and resume markdown files into profiles/cv and profiles/resume subdirectories with language splits
- update site generation, Typst templates, and scripts to read from the new locations and keep cross-language links working
- refresh repository documentation and backlog tasks to reference the reorganized paths

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo fmt --manifest-path scripts/convert_cv/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- cargo test --manifest-path scripts/convert_cv/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

## Avatar
- Software Architect — selected to plan and execute repository structure improvements.

------
https://chatgpt.com/codex/tasks/task_e_68cb129521a08332adf3158be26c4dfd