### PR TITLE
Add HeadHunter secret preflight gate

### DIFF
--- a/.github/workflows/hh-promote.yml
+++ b/.github/workflows/hh-promote.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       ready: ${{ steps.secrets.outputs.ready }}
       missing: ${{ steps.secrets.outputs.missing }}
+      missing_count: ${{ steps.secrets.outputs.missing_count }}
     steps:
       - name: Check HeadHunter secrets
         id: secrets
@@ -72,7 +73,8 @@ jobs:
             fi
           done
 
-          if (( ${#missing[@]} > 0 )); then
+          missing_count=${#missing[@]}
+          if (( missing_count > 0 )); then
             missing_list="$(IFS=', '; echo "${missing[*]}")"
             printf '::warning::HeadHunter promote skipped; missing configuration: %s\n' \
               "$missing_list"
@@ -82,11 +84,13 @@ jobs:
             fi
             echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "missing=$missing_list" >> "$GITHUB_OUTPUT"
+            echo "missing_count=$missing_count" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "ready=true" >> "$GITHUB_OUTPUT"
           echo "missing=" >> "$GITHUB_OUTPUT"
+          echo "missing_count=0" >> "$GITHUB_OUTPUT"
 
   promote:
     needs: preflight


### PR DESCRIPTION
## Summary
- add a preflight job that inspects HeadHunter secrets, reports missing entries in the step summary, and skips promotion when configuration is incomplete. F:.github/workflows/hh-promote.yml#L19-L90
- gate the promotion steps behind the preflight output while keeping the existing publish flow for each resume. F:.github/workflows/hh-promote.yml#L91-L277
- declare workflow-level permissions, concurrency, and consistent cargo log coloring for the HeadHunter promote workflow. F:.github/workflows/hh-promote.yml#L8-L16
- expose the preflight `missing_count` output so callers and logs can see how many secrets are absent. F:.github/workflows/hh-promote.yml#L19-L90

## Testing
- wrkflw validate .github/workflows/hh-promote.yml
- cargo test --manifest-path sitegen/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
- gh workflow run hh-promote.yml --ref work (preflight job succeeded, promote skipped due to missing secrets)

## Avatar
- DevOps Engineer — requested for CI hardening and workflow verification.
