### PR TITLE
Enable extended Markdown parsing in convert_cv

### DIFF
--- a/scripts/convert_cv/src/main.rs
+++ b/scripts/convert_cv/src/main.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{html, Parser};
+use pulldown_cmark::{html, Options, Parser};
 use serde::Serialize;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -10,7 +10,7 @@ struct Resume {
 }
 
 fn convert(markdown: &str) -> Resume {
-    let parser = Parser::new(markdown);
+    let parser = Parser::new_ext(markdown, Options::all());
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
     Resume { body: html_output }
@@ -70,6 +70,14 @@ mod tests {
     fn renders_heading() {
         let res = convert("# Title");
         assert_eq!(res.body.trim(), "<h1>Title</h1>");
+    }
+
+    #[test]
+    fn renders_table_with_extended_features() {
+        let markdown = "| Header | Value |\n| --- | --- |\n| A | B |";
+        let res = convert(markdown);
+        let expected = "<table><thead><tr><th>Header</th><th>Value</th></tr></thead><tbody>\n<tr><td>A</td><td>B</td></tr>\n</tbody></table>\n";
+        assert_eq!(res.body, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- switch convert_cv to Parser::new_ext with Options::all so it matches sitegen's configuration
- add a unit test covering table markdown rendered with the extended options and assert the exact HTML

## Testing
- cargo fmt --manifest-path scripts/convert_cv/Cargo.toml
- cargo check --tests --benches --manifest-path scripts/convert_cv/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path scripts/convert_cv/Cargo.toml -- -D warnings
- cargo test --manifest-path scripts/convert_cv/Cargo.toml
- cargo test --manifest-path sitegen/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

## Avatar
- Senior Rust Developer — selected to work on the Rust CLI and regression tests.