### PR TITLE
Restore CI checks on main pushes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,9 @@ env:
   CARGO_TERM_PROGRESS_WHEN: never
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- enable the [CI: Build & Test workflow](.github/workflows/build-test.yml) on pushes to `main` so merged commits keep running PDF and site verification

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)

Avatar: DevOps Engineer — chosen to restore the CI automation and guard all verification steps.
