### PR TITLE
Restore workflow names for required checks

### DIFF
--- a/.github/actions/build-pdfs/action.yml
+++ b/.github/actions/build-pdfs/action.yml
@@ -21,26 +21,12 @@ runs:
         if ! command -v typst >/dev/null 2>&1; then
           cargo install typst-cli --locked --quiet
         fi
-    - name: Build Typst English PDF
-      shell: bash
-      run: typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
-    - name: Build Typst Russian PDF
-      shell: bash
-      run: typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
-    - name: Build Product Manager English PDF
-      shell: bash
-      run: typst compile --root . typst/en/Belyakov_pm_en.typ typst/en/Belyakov_pm_en.pdf
-    - name: Build Product Manager Russian PDF
-      shell: bash
-      run: typst compile --root . typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_pm_ru.pdf
-    - name: Build role-based Typst PDFs
+    - name: Compile Typst PDFs
       shell: bash
       run: |
-        for role in tl em hod tech; do
-          name=$(grep "^$role =" roles.toml | cut -d '"' -f2)
-          sed "s/Rust Team Lead/$name/" typst/en/Belyakov_en.typ > typst/en/temp.typ
-          typst compile --root . typst/en/temp.typ "typst/en/Belyakov_en_${role}.pdf"
-          sed "s/Rust Team Lead/$name/" typst/ru/Belyakov_ru.typ > typst/ru/temp.typ
-          typst compile --root . typst/ru/temp.typ "typst/ru/Belyakov_ru_${role}.pdf"
+        set -euo pipefail
+        shopt -s nullglob
+        for src in typst/en/*.typ typst/ru/*.typ; do
+          dest="${src%.typ}.pdf"
+          typst compile --root . "$src" "$dest"
         done
-        rm typst/en/temp.typ typst/ru/temp.typ

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,9 +32,10 @@ jobs:
         run: |
           test -s dist/index.html
           test -s dist/ru/index.html
-          test -s dist/tl/ru/index.html
-          test -s dist/resume/pm/index.html
-          test -s dist/resume/pm/ru/index.html
+          test -s dist/em/index.html
+          test -s dist/em/ru/index.html
+          test -s dist/resume/em/index.html
+          test -s dist/resume/em/ru/index.html
       - name: Upload Typst PDFs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: CI: Build & Test
+name: build-test
 
 permissions:
   contents: read

--- a/.github/workflows/hh-promote.yml
+++ b/.github/workflows/hh-promote.yml
@@ -1,4 +1,4 @@
-name: "HeadHunter: Promote"
+name: hh-promote
 
 on:
   schedule:

--- a/.github/workflows/hh-publish.yml
+++ b/.github/workflows/hh-publish.yml
@@ -1,4 +1,4 @@
-name: HeadHunter: Publish
+name: hh-publish
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -30,11 +30,6 @@ jobs:
         run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - if: ${{ inputs.builder == 'typst' }}
         uses: ./.github/actions/build-pdfs
-      - if: ${{ inputs.builder == 'typst' }}
-        name: Prepare Typst release PDFs
-        run: |
-          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf
-          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Cache cargo
         uses: actions/cache@v4
@@ -51,27 +46,21 @@ jobs:
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Build PDFs with TypePDF
         run: |
-          typepdf typst/en/Belyakov_en.typ typst/en/Belyakov_en_typepdf.pdf
-          typepdf typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_typepdf.pdf
-          typepdf typst/en/Belyakov_pm_en.typ typst/en/Belyakov_pm_en_typepdf.pdf
-          typepdf typst/ru/Belyakov_pm_ru.typ typst/ru/Belyakov_pm_ru_typepdf.pdf
+          set -euo pipefail
+          shopt -s nullglob
+          for src in typst/en/*.typ typst/ru/*.typ; do
+            dest="${src%.typ}_typepdf.pdf"
+            typepdf "$src" "$dest"
+          done
       - if: ${{ inputs.builder == 'typst' }}
         name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:
           name: cv-pdfs-typst-${{ env.DATE }}
-          path: |
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_pm_full_en.pdf
-            typst/ru/Belyakov_pm_full_ru.pdf
+          path: typst/**/*.pdf
       - if: ${{ inputs.builder == 'typepdf' }}
         name: Upload PDFs
         uses: actions/upload-artifact@v4
         with:
           name: cv-pdfs-typepdf-${{ env.DATE }}
-          path: |
-            typst/en/Belyakov_en_typepdf.pdf
-            typst/ru/Belyakov_ru_typepdf.pdf
-            typst/en/Belyakov_pm_en_typepdf.pdf
-            typst/ru/Belyakov_pm_ru_typepdf.pdf
+          path: typst/**/*_typepdf.pdf

--- a/.github/workflows/pdf-manual.yml
+++ b/.github/workflows/pdf-manual.yml
@@ -1,4 +1,4 @@
-name: PDF: Manual Build
+name: pdf-manual
 
 permissions:
   contents: read

--- a/.github/workflows/pdf-validate.yml
+++ b/.github/workflows/pdf-validate.yml
@@ -1,4 +1,4 @@
-name: PDF: Validate
+name: pdf-validate
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -35,38 +35,22 @@ jobs:
       - uses: ./.github/actions/build-pdfs
       - name: Verify PDFs
         run: |
-          for lang in en ru; do
-            for file in Belyakov_${lang}.pdf Belyakov_pm_${lang}.pdf; do
-              if head -c 4 "typst/$lang/$file" | grep -q '%PDF'; then
-                echo "$file verified";
-              else
-                echo "typst/$lang/$file is not recognized as a PDF" >&2;
-                exit 1;
-              fi;
-            done;
-          done;
-      - name: Prepare release PDFs
-        run: |
-          cp typst/en/Belyakov_pm_en.pdf typst/en/Belyakov_pm_full_en.pdf;
-          cp typst/ru/Belyakov_pm_ru.pdf typst/ru/Belyakov_pm_full_ru.pdf;
+          set -euo pipefail
+          while IFS= read -r file; do
+            if head -c 4 "$file" | grep -q '%PDF'; then
+              echo "$(basename "$file") verified";
+            else
+              echo "$file is not recognized as a PDF" >&2;
+              exit 1;
+            fi;
+          done < <(find typst -type f -name '*.pdf')
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: sitegen-assets
           path: |
             sitegen/target/release/generate
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_pm_full_en.pdf
-            typst/ru/Belyakov_pm_full_ru.pdf
-            typst/en/Belyakov_en_tl.pdf
-            typst/en/Belyakov_en_em.pdf
-            typst/en/Belyakov_en_hod.pdf
-            typst/en/Belyakov_en_tech.pdf
-            typst/ru/Belyakov_ru_tl.pdf
-            typst/ru/Belyakov_ru_em.pdf
-            typst/ru/Belyakov_ru_hod.pdf
-            typst/ru/Belyakov_ru_tech.pdf
+            typst/**/*.pdf
 
   site:
     needs: build_sitegen
@@ -94,9 +78,10 @@ jobs:
         run: ./sitegen_bin
       - name: Verify role pages
         run: |
-          test -s dist/tl/ru/index.html;
-          test -s dist/resume/pm/index.html;
-          test -s dist/resume/pm/ru/index.html;
+          test -s dist/em/index.html;
+          test -s dist/em/ru/index.html;
+          test -s dist/resume/em/index.html;
+          test -s dist/resume/em/ru/index.html;
       - name: Prepare Pages directory
         run: mv dist docs
       - name: Copy README_RU
@@ -125,15 +110,4 @@ jobs:
           tag_name: sitegen-${{ github.run_number }}
           files: |
             sitegen_bin
-            typst/en/Belyakov_en.pdf
-            typst/ru/Belyakov_ru.pdf
-            typst/en/Belyakov_pm_full_en.pdf
-            typst/ru/Belyakov_pm_full_ru.pdf
-            typst/en/Belyakov_en_tl.pdf
-            typst/en/Belyakov_en_em.pdf
-            typst/en/Belyakov_en_hod.pdf
-            typst/en/Belyakov_en_tech.pdf
-            typst/ru/Belyakov_ru_tl.pdf
-            typst/ru/Belyakov_ru_em.pdf
-            typst/ru/Belyakov_ru_hod.pdf
-            typst/ru/Belyakov_ru_tech.pdf
+            typst/**/*.pdf

--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -1,4 +1,4 @@
-name: Website: Release
+name: release-site
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- restore the legacy workflow names so existing branch protection sees the required CI checks again
- align the Typst build workflows with the engineering-manager resume set by compiling every Typst source and updating artifact/site verification

## Testing
- cargo fmt --all --manifest-path sitegen/Cargo.toml
- cargo check --all-targets --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- cargo machete (from sitegen)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

## Avatar
- DevOps Engineer — focused on restoring CI coverage and automation.