### PR TITLE
Fix RocksDB spelling in CV profile

### DIFF
--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -71,12 +71,12 @@ Hands-on Engineering Manager and DevOps champion with nearly 10 years of leading
 *March 2023 — March 2024 (1 year)*
 
 - Enhanced the architecture of a hardware-software complex for deduplication-based backup solutions.
-- Conducted research on optimizing RoksDB and enhancing NVMe disk performance.
+- Conducted research on optimizing RocksDB and enhancing NVMe disk performance.
 - Implemented data structures for efficient storage of hashes and hash-hashes.
 - Resolved bugs and improved compression and deduplication modules.
 - Conducted code reviews and delivered internal lectures on Rust to transition ex-C++ developers to idiomatic Rust, decreasing onboarding time by 30%.
 
-**Technologies**: Rust, Tokio, Protocol Buffers, Serde, RoksDB, Git.
+**Technologies**: Rust, Tokio, Protocol Buffers, Serde, RocksDB, Git.
 
 ### Senior Rust/Python Developer (Part-Time) @ Ultima-bi
 *Nov 2022 - Mar 2023 (5 months)*

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -101,12 +101,12 @@
 *March 2023 — March 2024 (1 year)*
 
 - Enhanced the architecture of a hardware-software complex for deduplication-based backup solutions.
-- Conducted research on optimizing RoksDB and enhancing NVMe disk performance.
+- Conducted research on optimizing RocksDB and enhancing NVMe disk performance.
 - Implemented data structures for efficient storage of hashes and hash-hashes.
 - Resolved bugs and improved compression and deduplication modules.
 - Conducted code reviews and delivered internal lectures on Rust to transition ex-C++ developers to idiomatic Rust, decreasing onboarding time by 30%.
 
-**Technologies**: Rust, Tokio, Protocol Buffers, Serde, RoksDB, Git.
+**Technologies**: Rust, Tokio, Protocol Buffers, Serde, RocksDB, Git.
 
 ### Senior Rust/Python Developer (Part-Time) @ Ultima-bi
 *Nov 2022 - Mar 2023 (5 months)*


### PR DESCRIPTION
## Summary
- Correct the spelling of RocksDB in the YADRO section of the English CV profile
- Update the generated site fixture to keep snapshot tests green

## Testing
- `cargo test --manifest-path sitegen/Cargo.toml`
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`

## Avatar
- Senior Rust Developer — chosen for familiarity with the Rust ecosystem and common tooling such as RocksDB, ensuring terminology accuracy.


------
https://chatgpt.com/codex/tasks/task_e_68ccd82c3c84833293c6d4efb840f457