### PR TITLE
Update Russian link labels in CV output

### DIFF
--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -1,7 +1,7 @@
 # Alexey Leonidovich Belyakov
-*[Link to russian version](../ru/CV_RU.MD)* \\
+*[Link to Russian version](../ru/CV_RU.MD)* \\
 *[Link to PDF](https://qqrm.github.io/CV/Belyakov_en.pdf)* \\
-*[Link to russian PDF](https://qqrm.github.io/CV/Belyakov_ru.pdf)*
+*[Link to Russian PDF](https://qqrm.github.io/CV/Belyakov_ru.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -30,9 +30,9 @@
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
-<p><em><a href="ru/">Link to russian version</a></em> \
+<p><em><a href="ru/">Link to Russian version</a></em> \
 <em><a href="Belyakov_en.pdf">Link to PDF</a></em> \
-<em><a href="Belyakov_ru.pdf">Link to russian PDF</a></em></p>
+<em><a href="Belyakov_ru.pdf">Link to Russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -212,9 +212,9 @@
 
 </div>
 <footer>
-<p><em><a href="ru/">Link to russian version</a></em> \
+<p><em><a href="ru/">Link to Russian version</a></em> \
 <em><a href="Belyakov_en.pdf">Link to PDF</a></em> \
-<em><a href="Belyakov_ru.pdf">Link to russian PDF</a></em></p>
+<em><a href="Belyakov_ru.pdf">Link to Russian PDF</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>


### PR DESCRIPTION
## Summary
- Capitalize the Russian CV link labels in the English profile Markdown
- Synchronize the generated site fixture with the new link text

## Testing
- cargo fmt --all --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
- (cd sitegen && cargo machete)

## Avatar
- senior_developer — Selected for its focus on delivering reliable Rust changes and verifying the generator/tests.


------
https://chatgpt.com/codex/tasks/task_e_68ccd7ab5dd08332b701e4c72803b87c