### PR TITLE
Fix evangelized spelling in Engineering Manager CV

### DIFF
--- a/profiles/cv/en/CV_EM.MD
+++ b/profiles/cv/en/CV_EM.MD
@@ -34,7 +34,7 @@ Hands-on engineering leader and DevOps advocate who scales cross-functional team
 - Retained 90% of hires after the first year by pairing growth plans with consistent feedback loops.
 - Mentored three engineers to senior roles using a competency matrix and targeted coaching.
 - Integrated static analysis (Clippy, cargo-audit, SonarQube) and internal package distribution to satisfy compliance requirements.
-- Evangelised DevOps practices across teams, pairing incident reviews with automation backlogs and driving CI/CD adoption.
+- Evangelized DevOps practices across teams, pairing incident reviews with automation backlogs and driving CI/CD adoption.
 
 ### Rust Team Lead @ Solcery | March 2022 – March 2023
 - Managed a 4-person Rust team building a DAO-ready blockchain database on Solana.


### PR DESCRIPTION
## Summary
- Switch the Engineering Manager CV bullet to the US spelling "Evangelized" so the wording is consistent with the rest of the English profile. F:profiles/cv/en/CV_EM.MD#L33-L37
- Regenerated local Typst PDFs and HTML role pages to confirm the updated bullet propagates to published artifacts.

## Testing
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru.pdf
- cargo run --manifest-path sitegen/Cargo.toml --bin generate
- pdftotext typst/en/Belyakov_em_en.pdf - | rg -n "Evangelized"
- cargo run --manifest-path scripts/convert_cv/Cargo.toml profiles/cv/en/CV_EM.MD
- rg -o --color=never "Evangelized" /tmp/cv_em_en.json
- cargo test --manifest-path sitegen/Cargo.toml

## Avatar
- Senior Rust Developer — fits the documentation polish plus local build validation needed for this update.


------
https://chatgpt.com/codex/tasks/task_e_68ccd81b0cfc8332a683016710aa1d5f