### PR TITLE
Add company website links to Russian CV outputs

### DIFF
--- a/profiles/cv/ru/CV_RU.MD
+++ b/profiles/cv/ru/CV_RU.MD
@@ -20,7 +20,7 @@
 
 ## Опыт работы
 
-### Руководитель разработки @ Inline Group
+### Руководитель разработки @ Inline Group | [inlinegroup.ru](https://inlinegroup.ru)
 **March 2023 – Present**
 - Управлял командой аналитики через её лида, согласовывая приоритеты отчётности с продуктовой и инженерной повесткой.
 - Курировал QA-команду через её лида, усиливая регрессионное покрытие и контроль релизных критериев для микросервисов.
@@ -49,7 +49,7 @@
 ---
 
 <!--
-### Lead Rust Developer @ YADRO
+### Lead Rust Developer @ YADRO | [www.yadro.com](https://www.yadro.com)
 **март 2023 – март 2024 (1 год)**
 - Улучшал архитектуру аппаратно-программного комплекса для решения резервного копирования на базе дедупликации.
 - Изучал способы оптимизации RocksDB и повышения производительности NVMe-дисков.
@@ -86,7 +86,7 @@
 **Технологии**: Rust, Solana Test Validator, Git, GitHub
 -->
 
-### Senior Rust Developer @ Kaspersky Lab
+### Senior Rust Developer @ Kaspersky Lab | [www.kaspersky.ru](https://www.kaspersky.ru)
 **March 2020 – March 2023 (3 years)**
 - Поддерживал и развивал блокчейн-сервис голосования на базе Exonum, добавляя функциональность голосования с учётом «веса» участников.  
 - Расширил покрытие интеграционными и модульными тестами примерно до ~75%, укрепив общее качество кода.  
@@ -117,7 +117,7 @@
 ---
 -->
 
-### Senior C++/Go Developer @ B2Broker
+### Senior C++/Go Developer @ B2Broker | [www.b2broker.com](https://www.b2broker.com)
 **November 2018 – March 2020 (1 year 4 months)**
 - Разрабатывал финансовое ПО с использованием MT4/MT5 API, в том числе трейд-копиры на C++ и Go.  
 - Создал «Multi Account Manager» для гибкого распределения средств и расчёта вознаграждений, повышая операционную эффективность примерно на ~15%.  
@@ -128,7 +128,7 @@
 
 ---
 
-### Middle → Senior C++ Developer → Teamlead @ ASCON
+### Middle → Senior C++ Developer → Teamlead @ ASCON | [www.ascon.ru](https://www.ascon.ru)
 **May 2016 – November 2018 (2 years 7 months)**
 
 - Участвовал в разработке библиотек для архитектурного проектирования (KOMPAS), внедрив функцию «Change View Plane» для улучшения 3D-моделирования.
@@ -154,7 +154,7 @@
 
 ---
 
-### Middle C++/JS Developer @ LiveTex
+### Middle C++/JS Developer @ LiveTex | [livetex.ru](https://livetex.ru)
 **июль 2014 – март 2015 (7 месяцев)**
 - Создал обёртки для PostgreSQL и ZeroMQ под Node.js, сократив задержки выполнения запросов примерно на ~10%.
 
@@ -162,7 +162,7 @@
 
 ---
 
-### Junior C++ Developer @ Tools for Brokers
+### Junior C++ Developer @ Tools for Brokers | [t4b.com](https://www.t4b.com)
 **ноябрь 2013 – июль 2014 (9 месяцев)**
 - Выполнял разработку для платформ MetaTrader 4 и 5.
 - Улучшал и отлаживал плагин для взаимных фондов (UMAM).

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -49,7 +49,7 @@
 <h2>Цель</h2>
 <p>Руководитель разработки и евангелист DevOps с почти 10-летним опытом руководства бэкендом, QA и платформой. Увлечён выстраиванием стратегии релизов, автоматизацией quality gates и развитием микросервисных экосистем. Хочу масштабировать кросс-функциональные команды, сочетая стратегическое планирование, DevOps-губернанс и управление по метрикам, чтобы надёжно доставлять продукты с высоким бизнес-эффектом.</p>
 <h2>Опыт работы</h2>
-<h3>Руководитель разработки @ Inline Group</h3>
+<h3>Руководитель разработки @ Inline Group | <a href="https://inlinegroup.ru">inlinegroup.ru</a></h3>
 <p><strong>March 2023 – Present (DURATION)</strong></p>
 <ul>
 <li>Управлял командой аналитики через её лида, согласовывая приоритеты отчётности с продуктовой и инженерной повесткой.</li>
@@ -78,7 +78,7 @@
 <p><strong>Технологии</strong>: Rust, Actix Web, RabbitMQ, PostgreSQL, Docker, GitLab CI/CD, Odoo, Clippy, cargo-audit, SonarQube</p>
 <hr />
 <!--
-### Lead Rust Developer @ YADRO
+### Lead Rust Developer @ YADRO | [www.yadro.com](https://www.yadro.com)
 **март 2023 – март 2024 (1 год)**
 - Улучшал архитектуру аппаратно-программного комплекса для решения резервного копирования на базе дедупликации.
 - Изучал способы оптимизации RocksDB и повышения производительности NVMe-дисков.
@@ -114,7 +114,7 @@
 
 **Технологии**: Rust, Solana Test Validator, Git, GitHub
 -->
-<h3>Senior Rust Developer @ Kaspersky Lab</h3>
+<h3>Senior Rust Developer @ Kaspersky Lab | <a href="https://www.kaspersky.ru">www.kaspersky.ru</a></h3>
 <p><strong>March 2020 – March 2023 (3 years)</strong></p>
 <ul>
 <li>Поддерживал и развивал блокчейн-сервис голосования на базе Exonum, добавляя функциональность голосования с учётом «веса» участников.</li>
@@ -144,7 +144,7 @@
 
 ---
 -->
-<h3>Senior C++/Go Developer @ B2Broker</h3>
+<h3>Senior C++/Go Developer @ B2Broker | <a href="https://www.b2broker.com">www.b2broker.com</a></h3>
 <p><strong>November 2018 – March 2020 (1 year 4 months)</strong></p>
 <ul>
 <li>Разрабатывал финансовое ПО с использованием MT4/MT5 API, в том числе трейд-копиры на C++ и Go.</li>
@@ -154,7 +154,7 @@
 </ul>
 <p><strong>Технологии</strong>: MSVC, CMake, Protocol Buffers, gRPC, NATS, YAML, PostgreSQL, Vcpkg, Git</p>
 <hr />
-<h3>Middle → Senior C++ Developer → Teamlead @ ASCON</h3>
+<h3>Middle → Senior C++ Developer → Teamlead @ ASCON | <a href="https://www.ascon.ru">www.ascon.ru</a></h3>
 <p><strong>May 2016 – November 2018 (2 years 7 months)</strong></p>
 <ul>
 <li>Участвовал в разработке библиотек для архитектурного проектирования (KOMPAS), внедрив функцию «Change View Plane» для улучшения 3D-моделирования.</li>
@@ -178,7 +178,7 @@
 
 ---
 
-### Middle C++/JS Developer @ LiveTex
+### Middle C++/JS Developer @ LiveTex | [livetex.ru](https://livetex.ru)
 **июль 2014 – март 2015 (7 месяцев)**
 - Создал обёртки для PostgreSQL и ZeroMQ под Node.js, сократив задержки выполнения запросов примерно на ~10%.
 
@@ -186,7 +186,7 @@
 
 ---
 
-### Junior C++ Developer @ Tools for Brokers
+### Junior C++ Developer @ Tools for Brokers | [t4b.com](https://www.t4b.com)
 **ноябрь 2013 – июль 2014 (9 месяцев)**
 - Выполнял разработку для платформ MetaTrader 4 и 5.
 - Улучшал и отлаживал плагин для взаимных фондов (UMAM).


### PR DESCRIPTION
## Summary
- Added the missing company website links to the Russian CV headings so they mirror the English profile metadata. F:profiles/cv/ru/CV_RU.MD#L23-L165
- Updated the Russian HTML fixture so the rendered site shows the same company URLs in visible headings and comments. F:sitegen/tests/fixtures/ru/index.html#L52-L189

## Testing
- `typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf`
- `typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo test --manifest-path sitegen/Cargo.toml`

## Avatar
- Rust Tech Lead — chosen to ensure the content, fixtures, and build outputs stay aligned while coordinating the broader validation workflow.


------
https://chatgpt.com/codex/tasks/task_e_68ccd7abc14883329cb1836c69a39fd5