### PR TITLE
Remove leadership highlights section

### DIFF
--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -27,13 +27,6 @@ Hands-on Engineering Manager and DevOps champion with nearly 10 years of leading
 - Talent development, performance reviews, and hiring
 - DevOps strategy, release governance, and SRE collaboration
 
-## Leadership Highlights
-- Coordinated cross-functional teams, aligning backend, QA, and DevOps efforts to meet shared milestones.
-- Oversaw roadmap planning and resource allocation, keeping delivery within 5% of budget and ~90% KPI adherence.
-- Established regular performance review cycles, mentoring developers with actionable feedback and growth plans.
-- Communicated progress and risks to stakeholders, translating technical status into clear business insights.
-- Directed release orchestration through CI/CD standards, SAST policies, and deployment readiness reviews to keep launches predictable.
-
 ## Work Experience
 
 ### Engineering Manager @ Inline Group | [inlinegroup.ru](https://inlinegroup.ru)

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -58,14 +58,6 @@
 <li>Talent development, performance reviews, and hiring</li>
 <li>DevOps strategy, release governance, and SRE collaboration</li>
 </ul>
-<h2>Leadership Highlights</h2>
-<ul>
-<li>Coordinated cross-functional teams, aligning backend, QA, and DevOps efforts to meet shared milestones.</li>
-<li>Oversaw roadmap planning and resource allocation, keeping delivery within 5% of budget and ~90% KPI adherence.</li>
-<li>Established regular performance review cycles, mentoring developers with actionable feedback and growth plans.</li>
-<li>Communicated progress and risks to stakeholders, translating technical status into clear business insights.</li>
-<li>Directed release orchestration through CI/CD standards, SAST policies, and deployment readiness reviews to keep launches predictable.</li>
-</ul>
 <h2>Work Experience</h2>
 <h3>Engineering Manager @ Inline Group | <a href="https://inlinegroup.ru">inlinegroup.ru</a></h3>
 <p><em>March 2023 – Present (DURATION)</em></p>


### PR DESCRIPTION
## Summary
- remove the "Leadership Highlights" section from the English CV profile
- update the site generator HTML fixture to match the new layout without the highlights block

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru.pdf

------
https://chatgpt.com/codex/tasks/task_e_68cdfc46a13483329722a2d39f7028d0