### PR TITLE
Add theme-aware resume download links

### DIFF
--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -60,8 +60,20 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var attr = theme === 'dark' ? 'data-dark-href' : 'data-light-href';
+    var links = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var target = link.getAttribute(attr);
+      if (target) {
+        link.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -194,10 +194,10 @@
 </div>
 <footer>
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -224,8 +224,20 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var attr = theme === 'dark' ? 'data-dark-href' : 'data-light-href';
+    var links = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var target = link.getAttribute(attr);
+      if (target) {
+        link.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -189,10 +189,10 @@
 </div>
 <footer>
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -219,8 +219,20 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var attr = theme === 'dark' ? 'data-dark-href' : 'data-light-href';
+    var links = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var target = link.getAttribute(attr);
+      if (target) {
+        link.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';


### PR DESCRIPTION
## Summary
- add a helper that annotates every generated resume link with light/dark data attributes and applies it across base, localized, role, and resume pages
- extend the page template to switch resume download URLs based on the persisted theme and the runtime toggle state
- update fixtures and integration tests to validate the new attributes and ensure light-theme links remain the no-JS default

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf

------
https://chatgpt.com/codex/tasks/task_e_68cf3e9987dc8332b3d9466eebe79dd5