### PR TITLE
Add dynamic theme-aware resume downloads

### DIFF
--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -60,6 +60,25 @@ fn inject_duration(html: &mut String, fragment: &str, duration: &str) -> bool {
     }
 }
 
+fn annotate_resume_links(html: &mut String) {
+    let re =
+        Regex::new(r#"href=\"([^\"]*?)_(light|dark)\.pdf\""#).expect("invalid resume link regex");
+    if re.is_match(html) {
+        *html = re
+            .replace_all(html, |caps: &regex::Captures| {
+                let prefix = caps.get(1).unwrap().as_str();
+                let light_href = format!("{prefix}_light.pdf");
+                let dark_href = format!("{prefix}_dark.pdf");
+                format!(
+                    "href=\"{light}\" data-light-href=\"{light}\" data-dark-href=\"{dark}\"",
+                    light = light_href,
+                    dark = dark_href
+                )
+            })
+            .into_owned();
+    }
+}
+
 fn russian_month_name(month: u32) -> Option<&'static str> {
     const RU_MONTHS: [&str; 12] = [
         "январь",
@@ -188,6 +207,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Some(end) = html_body_en.find("</h1>") {
         html_body_en = html_body_en[end + 5..].trim_start().to_string();
     }
+    annotate_resume_links(&mut html_body_en);
 
     let markdown_ru = fs::read_to_string("profiles/cv/ru/CV_RU.MD")?;
     let parser_ru = CmarkParser::new_ext(&markdown_ru, Options::all());
@@ -228,6 +248,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Some(end) = html_body_ru.find("</h1>") {
         html_body_ru = html_body_ru[end + 5..].trim_start().to_string();
     }
+    annotate_resume_links(&mut html_body_ru);
 
     let footer_links_en = extract_first_paragraph(&html_body_en);
     let footer_links_ru = extract_first_paragraph(&html_body_ru);
@@ -258,6 +279,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if let Some(end) = html_resume_en.find("</h1>") {
             html_resume_en = html_resume_en[end + 5..].trim_start().to_string();
         }
+        annotate_resume_links(&mut html_resume_en);
 
         let markdown_resume_ru = fs::read_to_string(ru_md)?;
         let parser_resume_ru = CmarkParser::new_ext(&markdown_resume_ru, Options::all());
@@ -276,6 +298,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if let Some(end) = html_resume_ru.find("</h1>") {
             html_resume_ru = html_resume_ru[end + 5..].trim_start().to_string();
         }
+        annotate_resume_links(&mut html_resume_ru);
 
         let footer_links_resume_en = extract_first_paragraph(&html_resume_en);
         let footer_links_resume_ru = extract_first_paragraph(&html_resume_ru);
@@ -394,6 +417,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             html_body_en_role = html_body_en_role.replace(&base_en, &role_en);
             html_body_en_role = html_body_en_role.replace(&base_ru, &role_ru);
         }
+        annotate_resume_links(&mut html_body_en_role);
         let footer_links_en_role = extract_first_paragraph(&html_body_en_role);
         let en_role_html = render_page(&TemplateData {
             lang: "en",
@@ -428,6 +452,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             html_body_ru_role = html_body_ru_role.replace(&base_ru, &role_ru);
             html_body_ru_role = html_body_ru_role.replace(&base_en, &role_en);
         }
+        annotate_resume_links(&mut html_body_ru_role);
         let footer_links_ru_role = extract_first_paragraph(&html_body_ru_role);
         let ru_role_html = render_page(&TemplateData {
             lang: "ru",

--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -60,8 +60,22 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < anchors.length; i++) {
+      var anchor = anchors[i];
+      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+      if (!target) {
+        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      }
+      if (target) {
+        anchor.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -194,10 +194,10 @@
 </div>
 <footer>
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -224,8 +224,22 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < anchors.length; i++) {
+      var anchor = anchors[i];
+      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+      if (!target) {
+        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      }
+      if (target) {
+        anchor.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -189,10 +189,10 @@
 </div>
 <footer>
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -219,8 +219,22 @@
 (function(){
   var root = document.documentElement;
   var key = 'theme';
+  function updateResumeLinks(theme){
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    for (var i = 0; i < anchors.length; i++) {
+      var anchor = anchors[i];
+      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+      if (!target) {
+        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      }
+      if (target) {
+        anchor.setAttribute('href', target);
+      }
+    }
+  }
   function apply(theme){
     root.setAttribute('data-theme', theme);
+    updateResumeLinks(theme);
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var next = theme === 'light' ? 'dark' : 'light';


### PR DESCRIPTION
## Summary
- add data-light-href/data-dark-href attributes when generating resume links so light PDFs remain the default
- update the template script to swap resume download hrefs when the theme toggle changes and extend fixtures/tests accordingly

## Testing
- cargo fmt --all --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf
- wrkflw validate
- wrkflw run .github/workflows/build-test.yml (fails: Docker unavailable)
- python manual verification script for resume links

------
https://chatgpt.com/codex/tasks/task_e_68cf3c1650ac83328264b796d02c61c4