### PR TITLE
Enhance resume links with tooltips and labels

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -500,6 +500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1363,7 @@ dependencies = [
  "chrono",
  "env_logger",
  "handlebars",
+ "html-escape",
  "log",
  "phf 0.11.3",
  "pulldown-cmark",
@@ -1632,6 +1642,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -13,6 +13,7 @@ env_logger = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 handlebars = "5"
 regex = "1"
+html-escape = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -61,15 +61,62 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
+    var groups = {};
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-      if (!target) {
-        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
+      if (!groups[key]) {
+        groups[key] = [];
       }
-      if (target) {
-        anchor.setAttribute('href', target);
+      groups[key].push(anchor);
+    }
+    for (var key in groups) {
+      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
+      var list = groups[key];
+      var hasLight = false;
+      var hasDark = false;
+      for (var j = 0; j < list.length; j++) {
+        var variantValue = list[j].getAttribute('data-variant');
+        if (variantValue === 'light') {
+          hasLight = true;
+        } else if (variantValue === 'dark') {
+          hasDark = true;
+        }
+      }
+      var shouldToggle = hasLight && hasDark;
+      for (var j = 0; j < list.length; j++) {
+        var anchor = list[j];
+        var variant = anchor.getAttribute('data-variant');
+        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+        if (!target) {
+          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+        }
+        if (target) {
+          anchor.setAttribute('href', target);
+        }
+        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
+        if (label) {
+          anchor.textContent = label;
+        }
+        var tooltip = anchor.getAttribute('data-tooltip');
+        if (tooltip) {
+          anchor.setAttribute('title', tooltip);
+          anchor.setAttribute('aria-label', tooltip);
+        } else {
+          anchor.removeAttribute('title');
+          anchor.removeAttribute('aria-label');
+        }
+        var parent = anchor.parentElement;
+        var displayTarget = anchor;
+        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
+          displayTarget = parent;
+        }
+        if (shouldToggle && variant && variant !== theme) {
+          displayTarget.style.display = 'none';
+        } else {
+          displayTarget.style.display = '';
+        }
       }
     }
   }

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="light" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to dark theme to access Dark PDF">Light PDF</a></em> \
+<em><a href="Belyakov_en_dark.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to light theme to access Light PDF">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to dark theme to access Dark Russian PDF">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_dark.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to light theme to access Light Russian PDF">Dark Russian PDF</a></em></p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -194,10 +194,10 @@
 </div>
 <footer>
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Light PDF</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="light" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to dark theme to access Dark PDF">Light PDF</a></em> \
+<em><a href="Belyakov_en_dark.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to light theme to access Light PDF">Dark PDF</a></em> \
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to dark theme to access Dark Russian PDF">Light Russian PDF</a></em> \
+<em><a href="Belyakov_ru_dark.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to light theme to access Light Russian PDF">Dark Russian PDF</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -225,15 +225,62 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
+    var groups = {};
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-      if (!target) {
-        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
+      if (!groups[key]) {
+        groups[key] = [];
       }
-      if (target) {
-        anchor.setAttribute('href', target);
+      groups[key].push(anchor);
+    }
+    for (var key in groups) {
+      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
+      var list = groups[key];
+      var hasLight = false;
+      var hasDark = false;
+      for (var j = 0; j < list.length; j++) {
+        var variantValue = list[j].getAttribute('data-variant');
+        if (variantValue === 'light') {
+          hasLight = true;
+        } else if (variantValue === 'dark') {
+          hasDark = true;
+        }
+      }
+      var shouldToggle = hasLight && hasDark;
+      for (var j = 0; j < list.length; j++) {
+        var anchor = list[j];
+        var variant = anchor.getAttribute('data-variant');
+        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+        if (!target) {
+          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+        }
+        if (target) {
+          anchor.setAttribute('href', target);
+        }
+        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
+        if (label) {
+          anchor.textContent = label;
+        }
+        var tooltip = anchor.getAttribute('data-tooltip');
+        if (tooltip) {
+          anchor.setAttribute('title', tooltip);
+          anchor.setAttribute('aria-label', tooltip);
+        } else {
+          anchor.removeAttribute('title');
+          anchor.removeAttribute('aria-label');
+        }
+        var parent = anchor.parentElement;
+        var displayTarget = anchor;
+        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
+          displayTarget = parent;
+        }
+        if (shouldToggle && variant && variant !== theme) {
+          displayTarget.style.display = 'none';
+        } else {
+          displayTarget.style.display = '';
+        }
       }
     }
   }

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to dark theme to access Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_dark.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to light theme to access Скачать PDF (светлая тема)">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="light" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to dark theme to access Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_dark.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to light theme to access Download PDF (EN, light)">Download PDF (EN, dark)</a></em></p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -189,10 +189,10 @@
 </div>
 <footer>
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to dark theme to access Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
+<em><a href="../Belyakov_ru_dark.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to light theme to access Скачать PDF (светлая тема)">Скачать PDF (тёмная тема)</a></em> \
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="light" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to dark theme to access Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
+<em><a href="../Belyakov_en_dark.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to light theme to access Download PDF (EN, light)">Download PDF (EN, dark)</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -220,15 +220,62 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href]');
+    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
+    var groups = {};
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-      if (!target) {
-        target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
+      if (!groups[key]) {
+        groups[key] = [];
       }
-      if (target) {
-        anchor.setAttribute('href', target);
+      groups[key].push(anchor);
+    }
+    for (var key in groups) {
+      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
+      var list = groups[key];
+      var hasLight = false;
+      var hasDark = false;
+      for (var j = 0; j < list.length; j++) {
+        var variantValue = list[j].getAttribute('data-variant');
+        if (variantValue === 'light') {
+          hasLight = true;
+        } else if (variantValue === 'dark') {
+          hasDark = true;
+        }
+      }
+      var shouldToggle = hasLight && hasDark;
+      for (var j = 0; j < list.length; j++) {
+        var anchor = list[j];
+        var variant = anchor.getAttribute('data-variant');
+        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
+        if (!target) {
+          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
+        }
+        if (target) {
+          anchor.setAttribute('href', target);
+        }
+        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
+        if (label) {
+          anchor.textContent = label;
+        }
+        var tooltip = anchor.getAttribute('data-tooltip');
+        if (tooltip) {
+          anchor.setAttribute('title', tooltip);
+          anchor.setAttribute('aria-label', tooltip);
+        } else {
+          anchor.removeAttribute('title');
+          anchor.removeAttribute('aria-label');
+        }
+        var parent = anchor.parentElement;
+        var displayTarget = anchor;
+        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
+          displayTarget = parent;
+        }
+        if (shouldToggle && variant && variant !== theme) {
+          displayTarget.style.display = 'none';
+        } else {
+          displayTarget.style.display = '';
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add html-escape dependency and extend annotate_resume_links to capture variant labels, tooltips, and default hrefs
- update the page template to hide inactive PDF variants, refresh labels, and expose tooltip hints via title and aria-label
- refresh fixtures and tests to reflect single-link-per-theme markup and validate visibility and tooltips

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml --all
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo run --manifest-path sitegen/Cargo.toml --bin generate
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)

------
https://chatgpt.com/codex/tasks/task_e_68cfb0f567708332b4758a8893968108