### PR TITLE
Align resume template palette with site colors

### DIFF
--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -6,14 +6,14 @@
     light: (
       background: rgb("#ffffff"),
       text: rgb("#1f2933"),
-      muted: rgb("#94a3b8"),
-      link: rgb("#2563eb"),
+      muted: rgb("#7b8794"),
+      link: rgb("#0645ad"),
     ),
     dark: (
-      background: rgb("#0f172a"),
-      text: rgb("#e2e8f0"),
-      muted: rgb("#475569"),
-      link: rgb("#93c5fd"),
+      background: rgb("#121212"),
+      text: rgb("#e0e0e0"),
+      muted: rgb("#7b8794"),
+      link: rgb("#9cdcfe"),
     ),
   )
   #let palette = themes.at(theme, default: themes.light)


### PR DESCRIPTION
## Summary
- update the Typst resume theme map to match the site palette, including the shared muted gray and updated link colors
- regenerate the English and Russian light/dark PDFs and spot-check color components to ensure the new palette renders correctly

## Testing
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)


------
https://chatgpt.com/codex/tasks/task_e_68cfbf45be3883328965b11dc779369d