### PR TITLE
Serialize role maps with serde_json

### DIFF
--- a/sitegen/Cargo.lock
+++ b/sitegen/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "regex",
  "scraper",
  "serde",
+ "serde_json",
  "serial_test",
  "tempfile",
  "toml",

--- a/sitegen/Cargo.toml
+++ b/sitegen/Cargo.toml
@@ -14,6 +14,7 @@ phf = { version = "0.11", features = ["macros"] }
 handlebars = "5"
 regex = "1"
 html-escape = "0.2"
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -204,8 +204,8 @@
   <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5" fill="none" stroke="currentColor" stroke-width="2"/><g stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="1.5" x2="12" y2="4.5"/><line x1="12" y1="19.5" x2="12" y2="22.5"/><line x1="1.5" y1="12" x2="4.5" y2="12"/><line x1="19.5" y1="12" x2="22.5" y2="12"/><line x1="4.22" y1="4.22" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/><line x1="4.22" y1="19.78" x2="6.34" y2="17.66"/></g></svg>
 </button>
 <script>
-    const positions = { em: 'Engineering Manager' };
-    const positionsRu = { em: 'Руководитель разработки' };
+    const positions = {"em":"Engineering Manager"};
+    const positionsRu = {"em":"Руководитель разработки"};
     const segments = window.location.pathname.split('/').filter(Boolean);
     const slug = segments.reverse().find(s => positions[s]);
     const position = document.getElementById('position');

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -199,8 +199,8 @@
   <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5" fill="none" stroke="currentColor" stroke-width="2"/><g stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="1.5" x2="12" y2="4.5"/><line x1="12" y1="19.5" x2="12" y2="22.5"/><line x1="1.5" y1="12" x2="4.5" y2="12"/><line x1="19.5" y1="12" x2="22.5" y2="12"/><line x1="4.22" y1="4.22" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/><line x1="4.22" y1="19.78" x2="6.34" y2="17.66"/></g></svg>
 </button>
 <script>
-    const positions = { em: 'Engineering Manager' };
-    const positionsRu = { em: 'Руководитель разработки' };
+    const positions = {"em":"Engineering Manager"};
+    const positionsRu = {"em":"Руководитель разработки"};
     const segments = window.location.pathname.split('/').filter(Boolean);
     const slug = segments.reverse().find(s => positions[s]);
     const position = document.getElementById('position');

--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -1,7 +1,8 @@
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
 
 use chrono::{Datelike, NaiveDate, Utc};
 use regex::Regex;
@@ -172,6 +173,7 @@ fn assert_pdf_link_attrs(html: &str, light: &str, dark: &str) {
 }
 
 #[test]
+#[serial_test::serial]
 fn generates_expected_dist() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let project_root = crate_dir.parent().expect("project root");
@@ -368,4 +370,96 @@ fn generates_expected_dist() {
     }
 
     fs::remove_dir_all(&dist).expect("failed to remove dist");
+}
+
+#[test]
+#[serial_test::serial]
+fn generates_roles_script_with_json_encoding() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().expect("project root");
+    let roles_path = project_root.join("roles.toml");
+    let original_roles = fs::read_to_string(&roles_path).expect("read roles.toml for script test");
+
+    struct RolesTomlGuard {
+        path: PathBuf,
+        original: String,
+    }
+
+    impl Drop for RolesTomlGuard {
+        fn drop(&mut self) {
+            if let Err(err) = fs::write(&self.path, &self.original) {
+                if !thread::panicking() {
+                    panic!("failed to restore roles.toml: {err}");
+                }
+            }
+        }
+    }
+
+    let _guard = RolesTomlGuard {
+        path: roles_path.clone(),
+        original: original_roles.clone(),
+    };
+
+    let mut updated_roles = original_roles;
+    if !updated_roles.ends_with('\n') {
+        updated_roles.push('\n');
+    }
+    updated_roles.push_str("lead-role = \"Lead's Role\"\n");
+    fs::write(&roles_path, updated_roles).expect("write roles.toml for script test");
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--manifest-path",
+            "sitegen/Cargo.toml",
+            "--bin",
+            "generate",
+        ])
+        .current_dir(project_root)
+        .status()
+        .expect("failed to run generate for script test");
+    assert!(status.success(), "generate command failed in script test");
+
+    let dist = project_root.join("dist");
+    let index_path = dist.join("index.html");
+    let index_html = fs::read_to_string(&index_path).expect("read index.html for script test");
+
+    let positions_re =
+        Regex::new(r"const positions = (?P<json>\{[^;]*\});").expect("positions regex");
+    let positions_caps = positions_re
+        .captures(&index_html)
+        .expect("positions script not found");
+    let positions_json = positions_caps
+        .name("json")
+        .map(|m| m.as_str())
+        .expect("positions json group");
+    let parsed_positions: serde_json::Value =
+        serde_json::from_str(positions_json).expect("positions JSON invalid");
+    assert_eq!(
+        parsed_positions
+            .get("lead-role")
+            .and_then(|value| value.as_str()),
+        Some("Lead's Role"),
+        "expected lead-role entry in positions JSON"
+    );
+
+    let positions_ru_re =
+        Regex::new(r"const positionsRu = (?P<json>\{[^;]*\});").expect("positionsRu regex");
+    let positions_ru_caps = positions_ru_re
+        .captures(&index_html)
+        .expect("positionsRu script not found");
+    let positions_ru_json = positions_ru_caps
+        .name("json")
+        .map(|m| m.as_str())
+        .expect("positionsRu json group");
+    let parsed_positions_ru: serde_json::Value =
+        serde_json::from_str(positions_ru_json).expect("positionsRu JSON invalid");
+    assert!(
+        parsed_positions_ru.get("lead-role").is_some(),
+        "expected lead-role entry in positionsRu JSON"
+    );
+
+    if dist.exists() {
+        fs::remove_dir_all(&dist).expect("failed to remove dist");
+    }
 }


### PR DESCRIPTION
## Summary
- replace the handwritten JavaScript role map formatting with serde_json serialization for both locales
- add an integration test that temporarily augments roles.toml, verifies the generated scripts parse as JSON, and cleans up afterwards
- refresh the HTML fixtures to reflect the new JSON-encoded role data

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)


------
https://chatgpt.com/codex/tasks/task_e_68cfdbb9040483329d7792ae988a8081