### PR TITLE
Fix engineering manager resume PDFs to use resume content

### DIFF
--- a/typst/en/Belyakov_em_en.typ
+++ b/typst/en/Belyakov_em_en.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Engineering Manager", md_path: "../profiles/cv/en/CV_EM.MD")
+#resume(lang: "en", role: "Engineering Manager")

--- a/typst/en/Belyakov_em_en_dark.typ
+++ b/typst/en/Belyakov_em_en_dark.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "en", role: "Engineering Manager", md_path: "../profiles/cv/en/CV_EM.MD", theme: "dark")
+#resume(lang: "en", role: "Engineering Manager", theme: "dark")

--- a/typst/ru/Belyakov_em_ru.typ
+++ b/typst/ru/Belyakov_em_ru.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Руководитель разработки", md_path: "../profiles/cv/ru/CV_EM_RU.MD")
+#resume(lang: "ru", role: "Руководитель разработки")

--- a/typst/ru/Belyakov_em_ru_dark.typ
+++ b/typst/ru/Belyakov_em_ru_dark.typ
@@ -1,2 +1,2 @@
 #import "../../templates/resume.typ": resume
-#resume(lang: "ru", role: "Руководитель разработки", md_path: "../profiles/cv/ru/CV_EM_RU.MD", theme: "dark")
+#resume(lang: "ru", role: "Руководитель разработки", theme: "dark")


### PR DESCRIPTION
## Summary
- load resume markdown automatically for the engineering manager Typst sources so the generated PDFs contain the condensed resume content

## Testing
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf
- cargo fmt --all --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)


------
https://chatgpt.com/codex/tasks/task_e_68d0da3e67ec83328df1cb2d08f556f8