### PR TITLE
Add GitHub Pages PDF verification test

### DIFF
--- a/.github/workflows/codex-cleanup.yml
+++ b/.github/workflows/codex-cleanup.yml
@@ -1,0 +1,190 @@
+name: Codex Branch Cleanup
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-branch-cleanup-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cleanup:
+    name: cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: prune codex branches and pull requests
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const cutoffMs = 24 * 60 * 60 * 1000;
+            const now = Date.now();
+            const branchPrefix = 'codex/';
+            const codexAuthor = 'github-codex[bot]';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const repoInfo = await github.rest.repos.get({ owner, repo });
+            const defaultBranch = repoInfo.data.default_branch;
+            const protectedBranches = new Set([
+              defaultBranch,
+              'main',
+              'master',
+              'develop',
+              'production',
+              'prod',
+            ]);
+
+            const processedBranches = new Set();
+            const deletedBranches = [];
+            const skippedBranches = [];
+            const closedPulls = [];
+
+            core.info(`Repository default branch: ${defaultBranch}`);
+            core.info(`Evaluating branches with prefix "${branchPrefix}" older than ${cutoffMs / 3600000} hours.`);
+
+            const listBranches = await github.paginate(
+              github.rest.repos.listBranches,
+              { owner, repo, per_page: 100 }
+            );
+
+            function parseCommitDate(branch) {
+              const commit = branch?.commit?.commit;
+              return (
+                commit?.committer?.date ||
+                commit?.author?.date ||
+                null
+              );
+            }
+
+            async function deleteBranch(ref, reason) {
+              if (!ref) {
+                core.warning(`Skipping branch deletion: empty ref encountered (${reason}).`);
+                return false;
+              }
+
+              if (processedBranches.has(ref)) {
+                core.info(`Branch ${ref} already processed (${reason}).`);
+                return false;
+              }
+
+              if (!ref.startsWith(branchPrefix)) {
+                core.info(`Skipping branch ${ref}: does not match prefix ${branchPrefix}.`);
+                skippedBranches.push({ ref, reason: 'prefix-mismatch' });
+                processedBranches.add(ref);
+                return false;
+              }
+
+              if (protectedBranches.has(ref)) {
+                core.warning(`Refusing to delete protected branch ${ref} (${reason}).`);
+                skippedBranches.push({ ref, reason: 'protected' });
+                processedBranches.add(ref);
+                return false;
+              }
+
+              try {
+                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${ref}` });
+                core.info(`Deleted branch ${ref} (${reason}).`);
+                deletedBranches.push(ref);
+                processedBranches.add(ref);
+                return true;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Branch ${ref} already removed (${reason}).`);
+                } else {
+                  core.warning(`Failed to delete branch ${ref} (${reason}): ${error.message}`);
+                }
+                skippedBranches.push({ ref, reason: 'delete-failed', error: error.message });
+                processedBranches.add(ref);
+                return false;
+              }
+            }
+
+            for (const branch of listBranches) {
+              const name = branch.name;
+              const commitDateIso = parseCommitDate(branch);
+              if (!name.startsWith(branchPrefix)) {
+                continue;
+              }
+
+              if (protectedBranches.has(name)) {
+                core.info(`Skipping branch ${name}: protected name.`);
+                continue;
+              }
+
+              if (!commitDateIso) {
+                core.warning(`Skipping branch ${name}: unable to determine commit timestamp.`);
+                skippedBranches.push({ ref: name, reason: 'no-commit-timestamp' });
+                continue;
+              }
+
+              const commitTime = Date.parse(commitDateIso);
+              if (Number.isNaN(commitTime)) {
+                core.warning(`Skipping branch ${name}: invalid commit timestamp ${commitDateIso}.`);
+                skippedBranches.push({ ref: name, reason: 'invalid-timestamp' });
+                continue;
+              }
+
+              const ageMs = now - commitTime;
+              if (ageMs <= cutoffMs) {
+                core.info(`Branch ${name} age ${Math.round(ageMs / 3600000)}h is within retention.`);
+                continue;
+              }
+
+              await deleteBranch(name, `stale (${Math.round(ageMs / 3600000)}h old)`);
+            }
+
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 }
+            );
+
+            for (const pr of pulls) {
+              if (pr.user?.login !== codexAuthor) {
+                continue;
+              }
+
+              const created = Date.parse(pr.created_at);
+              if (!Number.isFinite(created)) {
+                core.warning(`Skipping PR #${pr.number}: invalid created_at ${pr.created_at}.`);
+                continue;
+              }
+
+              const ageMs = now - created;
+              if (ageMs <= cutoffMs) {
+                core.info(`PR #${pr.number} is ${Math.round(ageMs / 3600000)}h old; within retention.`);
+                continue;
+              }
+
+              core.info(`Closing PR #${pr.number} (${pr.title}) opened by ${codexAuthor}; age ${Math.round(ageMs / 3600000)}h.`);
+              try {
+                await github.rest.pulls.update({ owner, repo, pull_number: pr.number, state: 'closed' });
+                closedPulls.push(pr.number);
+              } catch (error) {
+                core.warning(`Failed to close PR #${pr.number}: ${error.message}`);
+                continue;
+              }
+
+              const headRef = pr.head?.ref;
+              await deleteBranch(headRef, `closed PR #${pr.number}`);
+            }
+
+            core.info(`Codex cleanup summary:`);
+            core.info(`  Deleted branches: ${deletedBranches.join(', ') || 'none'}`);
+            core.info(`  Closed pull requests: ${closedPulls.join(', ') || 'none'}`);
+            if (skippedBranches.length > 0) {
+              for (const entry of skippedBranches) {
+                core.info(`  Skipped ${entry.ref}: ${entry.reason}${entry.error ? ` (${entry.error})` : ''}`);
+              }
+            }

--- a/sitegen/tests/pdf_remote.rs
+++ b/sitegen/tests/pdf_remote.rs
@@ -1,0 +1,159 @@
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use walkdir::WalkDir;
+
+const BASE_URL: &str = "https://qqrm.github.io/CV/";
+const MIN_PDF_SIZE_BYTES: usize = 1024;
+
+struct DistGuard {
+    path: PathBuf,
+}
+
+impl DistGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for DistGuard {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            if let Err(err) = fs::remove_dir_all(&self.path) {
+                eprintln!(
+                    "failed to remove {} during cleanup: {}",
+                    self.path.display(),
+                    err
+                );
+            }
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn deployed_pdfs_are_real() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_dir.parent().expect("project root");
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--manifest-path",
+            "sitegen/Cargo.toml",
+            "--bin",
+            "generate",
+        ])
+        .current_dir(project_root)
+        .status()
+        .expect("failed to run generate");
+    assert!(status.success(), "generate command failed");
+
+    let dist = project_root.join("dist");
+    let _guard = DistGuard::new(dist.clone());
+
+    let mut pdfs = Vec::new();
+    for entry in WalkDir::new(&dist).into_iter().filter_map(Result::ok) {
+        if entry.file_type().is_file()
+            && entry
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.eq_ignore_ascii_case("pdf"))
+                .unwrap_or(false)
+        {
+            let relative = entry
+                .path()
+                .strip_prefix(&dist)
+                .expect("pdf to be inside dist")
+                .to_string_lossy()
+                .replace('\\', "/");
+            pdfs.push(relative);
+        }
+    }
+
+    pdfs.sort();
+    pdfs.dedup();
+
+    assert!(!pdfs.is_empty(), "no PDFs generated");
+
+    let mut errors = Vec::new();
+
+    for relative in &pdfs {
+        let url = format!("{BASE_URL}{relative}");
+        match ureq::get(&url).call() {
+            Ok(resp) => {
+                let status = resp.status();
+                if status >= 400 {
+                    errors.push(format!("{url} -> HTTP {status}"));
+                    continue;
+                }
+
+                let content_type = resp
+                    .header("Content-Type")
+                    .or_else(|| resp.header("content-type"))
+                    .map(str::to_owned)
+                    .unwrap_or_default();
+                if !content_type.contains("application/pdf") {
+                    errors.push(format!("{url} -> unexpected content-type '{content_type}'"));
+                    continue;
+                }
+
+                let mut reader = resp.into_reader();
+                let mut header = [0_u8; 5];
+                if let Err(err) = reader.read_exact(&mut header) {
+                    errors.push(format!("{url} -> failed to read header: {err}"));
+                    continue;
+                }
+                if &header != b"%PDF-" {
+                    errors.push(format!(
+                        "{url} -> invalid PDF signature: {}",
+                        String::from_utf8_lossy(&header)
+                    ));
+                    continue;
+                }
+
+                let mut total_bytes = header.len();
+                let mut buffer = [0_u8; 4096];
+                loop {
+                    match reader.read(&mut buffer) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            total_bytes += n;
+                        }
+                        Err(err) => {
+                            errors.push(format!("{url} -> read error after header: {err}"));
+                            break;
+                        }
+                    }
+                }
+
+                if total_bytes < MIN_PDF_SIZE_BYTES {
+                    errors.push(format!(
+                        "{url} -> unexpectedly small PDF ({} bytes)",
+                        total_bytes
+                    ));
+                }
+            }
+            Err(ureq::Error::Status(status, _)) => {
+                errors.push(format!("{url} -> HTTP {status}"));
+            }
+            Err(ureq::Error::Transport(err)) => {
+                let message = err.to_string();
+                if message.contains("Network is unreachable")
+                    || message.contains("failed to lookup address information")
+                {
+                    eprintln!("Skipping {url} due to network issue: {message}");
+                } else {
+                    errors.push(format!("{url} -> transport error: {message}"));
+                }
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        panic!("Deployed PDF verification failed:\n{}", errors.join("\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- add the Codex branch cleanup workflow required by the bootstrap rules
- add an integration test that fetches the deployed PDF files and asserts they are real PDFs, not placeholders

## Testing
- cargo fmt --all --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- cargo machete
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf
- wrkflw validate

------
https://chatgpt.com/codex/tasks/task_e_68d0dbcddc38833284e0f9ab3b224af7