### PR TITLE
Fix release workflow to ship Typst binary for site generation

### DIFF
--- a/.github/workflows/release-site.yml
+++ b/.github/workflows/release-site.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Build
         run: cargo build --release --manifest-path sitegen/Cargo.toml --quiet
       - uses: ./.github/actions/build-pdfs
+      - name: Package Typst binary
+        run: |
+          mkdir -p sitegen/target/release
+          cp ~/.cargo/bin/typst sitegen/target/release/typst
       - name: Verify PDFs
         run: |
           set -euo pipefail
@@ -50,6 +54,7 @@ jobs:
           name: sitegen-assets
           path: |
             sitegen/target/release/generate
+            sitegen/target/release/typst
             typst/**/*.pdf
 
   site:
@@ -66,6 +71,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sitegen-assets
+      - name: Install Typst binary
+        run: |
+          mkdir -p typst-bin
+          mv sitegen/target/release/typst typst-bin/typst
+          chmod +x typst-bin/typst
+          echo "$PWD/typst-bin" >> $GITHUB_PATH
       - name: Move sitegen binary
         run: mv sitegen/target/release/generate ./sitegen_bin
       - name: Make binary executable
@@ -76,6 +87,17 @@ jobs:
           rm -rf dist;
       - name: Generate site
         run: ./sitegen_bin
+      - name: Verify generated PDFs
+        run: |
+          set -euo pipefail
+          while IFS= read -r file; do
+            if head -c 4 "$file" | grep -q '%PDF'; then
+              echo "$(basename "$file") verified";
+            else
+              echo "$file is not recognized as a PDF" >&2;
+              exit 1;
+            fi;
+          done < <(find dist -type f -name '*.pdf')
       - name: Verify role pages
         run: |
           test -s dist/em/index.html;


### PR DESCRIPTION
## Summary
- bundle the Typst CLI produced during the build job into the sitegen artifact so the deploy job can compile PDFs on GitHub runners that lack Typst
- install the bundled Typst binary on the deploy runner and verify the generated PDFs so empty light-theme files are caught before publishing

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --tests --benches --manifest-path sitegen/Cargo.toml
- cargo clippy --all-targets --all-features --manifest-path sitegen/Cargo.toml -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- typst compile --root . typst/en/Belyakov_em_en.typ typst/en/Belyakov_em_en_light.pdf
- typst compile --root . typst/en/Belyakov_em_en_dark.typ typst/en/Belyakov_em_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_em_ru.typ typst/ru/Belyakov_em_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_em_ru_dark.typ typst/ru/Belyakov_em_ru_dark.pdf

Avatar: Senior Rust Developer (chosen because the task required diagnosing and fixing a Rust-based deployment pipeline).


------
https://chatgpt.com/codex/tasks/task_e_68d0ef2eb1b88332a07df1189e08cba7