### PR TITLE
Unify resume PDF anchors

### DIFF
--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -61,62 +61,45 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
-    var groups = {};
+    var anchors = document.querySelectorAll('a[data-light-href], a[data-dark-href]');
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
-      if (!groups[key]) {
-        groups[key] = [];
+      var lightHref = anchor.getAttribute('data-light-href');
+      var darkHref = anchor.getAttribute('data-dark-href');
+      var lightLabel = anchor.getAttribute('data-light-label');
+      var darkLabel = anchor.getAttribute('data-dark-label');
+      var hasLight = !!lightHref;
+      var hasDark = !!darkHref;
+
+      var targetHref = theme === 'dark' && hasDark ? darkHref : lightHref || darkHref;
+      if (!targetHref && hasDark) {
+        targetHref = darkHref;
       }
-      groups[key].push(anchor);
-    }
-    for (var key in groups) {
-      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
-      var list = groups[key];
-      var hasLight = false;
-      var hasDark = false;
-      for (var j = 0; j < list.length; j++) {
-        var variantValue = list[j].getAttribute('data-variant');
-        if (variantValue === 'light') {
-          hasLight = true;
-        } else if (variantValue === 'dark') {
-          hasDark = true;
-        }
+      if (targetHref) {
+        anchor.setAttribute('href', targetHref);
       }
-      var shouldToggle = hasLight && hasDark;
-      for (var j = 0; j < list.length; j++) {
-        var anchor = list[j];
-        var variant = anchor.getAttribute('data-variant');
-        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-        if (!target) {
-          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
-        }
-        if (target) {
-          anchor.setAttribute('href', target);
-        }
-        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
-        if (label) {
-          anchor.textContent = label;
-        }
-        var tooltip = anchor.getAttribute('data-tooltip');
-        if (tooltip) {
-          anchor.setAttribute('title', tooltip);
-          anchor.setAttribute('aria-label', tooltip);
-        } else {
-          anchor.removeAttribute('title');
-          anchor.removeAttribute('aria-label');
-        }
-        var parent = anchor.parentElement;
-        var displayTarget = anchor;
-        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
-          displayTarget = parent;
-        }
-        if (shouldToggle && variant && variant !== theme) {
-          displayTarget.style.display = 'none';
-        } else {
-          displayTarget.style.display = '';
-        }
+
+      var label;
+      if (theme === 'dark' && hasDark) {
+        label = darkLabel || lightLabel;
+      } else if (theme === 'dark') {
+        label = lightLabel || darkLabel;
+      } else {
+        label = lightLabel || darkLabel;
+      }
+      if (label) {
+        anchor.textContent = label;
+      }
+
+      if (hasLight && hasDark) {
+        var nextTheme = theme === 'dark' ? 'light' : 'dark';
+        var tooltipLabel = theme === 'dark' ? (lightLabel || 'Light PDF') : (darkLabel || 'Dark PDF');
+        var tooltip = 'Switch to ' + nextTheme + ' theme to access ' + tooltipLabel;
+        anchor.setAttribute('title', tooltip);
+        anchor.setAttribute('aria-label', tooltip);
+      } else {
+        anchor.removeAttribute('title');
+        anchor.removeAttribute('aria-label');
       }
     }
   }

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="light" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to dark theme to access Dark PDF">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to light theme to access Light PDF">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to dark theme to access Dark Russian PDF">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to light theme to access Light Russian PDF">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Light PDF" data-dark-label="Dark PDF">Light PDF</a></em> \
+
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF">Light Russian PDF</a></em> \
+</p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
 <li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -194,10 +194,10 @@
 </div>
 <footer>
 <p><em><a href="ru/">Link to Russian version</a></em> \
-<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="light" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to dark theme to access Dark PDF">Light PDF</a></em> \
-<em><a href="Belyakov_en_dark.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Light PDF" data-dark-label="Dark PDF" data-tooltip="Switch to light theme to access Light PDF">Dark PDF</a></em> \
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to dark theme to access Dark Russian PDF">Light Russian PDF</a></em> \
-<em><a href="Belyakov_ru_dark.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF" data-tooltip="Switch to light theme to access Light Russian PDF">Dark Russian PDF</a></em></p>
+<em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Light PDF" data-dark-label="Dark PDF">Light PDF</a></em> \
+
+<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF">Light Russian PDF</a></em> \
+</p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -225,62 +225,45 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
-    var groups = {};
+    var anchors = document.querySelectorAll('a[data-light-href], a[data-dark-href]');
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
-      if (!groups[key]) {
-        groups[key] = [];
+      var lightHref = anchor.getAttribute('data-light-href');
+      var darkHref = anchor.getAttribute('data-dark-href');
+      var lightLabel = anchor.getAttribute('data-light-label');
+      var darkLabel = anchor.getAttribute('data-dark-label');
+      var hasLight = !!lightHref;
+      var hasDark = !!darkHref;
+
+      var targetHref = theme === 'dark' && hasDark ? darkHref : lightHref || darkHref;
+      if (!targetHref && hasDark) {
+        targetHref = darkHref;
       }
-      groups[key].push(anchor);
-    }
-    for (var key in groups) {
-      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
-      var list = groups[key];
-      var hasLight = false;
-      var hasDark = false;
-      for (var j = 0; j < list.length; j++) {
-        var variantValue = list[j].getAttribute('data-variant');
-        if (variantValue === 'light') {
-          hasLight = true;
-        } else if (variantValue === 'dark') {
-          hasDark = true;
-        }
+      if (targetHref) {
+        anchor.setAttribute('href', targetHref);
       }
-      var shouldToggle = hasLight && hasDark;
-      for (var j = 0; j < list.length; j++) {
-        var anchor = list[j];
-        var variant = anchor.getAttribute('data-variant');
-        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-        if (!target) {
-          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
-        }
-        if (target) {
-          anchor.setAttribute('href', target);
-        }
-        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
-        if (label) {
-          anchor.textContent = label;
-        }
-        var tooltip = anchor.getAttribute('data-tooltip');
-        if (tooltip) {
-          anchor.setAttribute('title', tooltip);
-          anchor.setAttribute('aria-label', tooltip);
-        } else {
-          anchor.removeAttribute('title');
-          anchor.removeAttribute('aria-label');
-        }
-        var parent = anchor.parentElement;
-        var displayTarget = anchor;
-        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
-          displayTarget = parent;
-        }
-        if (shouldToggle && variant && variant !== theme) {
-          displayTarget.style.display = 'none';
-        } else {
-          displayTarget.style.display = '';
-        }
+
+      var label;
+      if (theme === 'dark' && hasDark) {
+        label = darkLabel || lightLabel;
+      } else if (theme === 'dark') {
+        label = lightLabel || darkLabel;
+      } else {
+        label = lightLabel || darkLabel;
+      }
+      if (label) {
+        anchor.textContent = label;
+      }
+
+      if (hasLight && hasDark) {
+        var nextTheme = theme === 'dark' ? 'light' : 'dark';
+        var tooltipLabel = theme === 'dark' ? (lightLabel || 'Light PDF') : (darkLabel || 'Dark PDF');
+        var tooltip = 'Switch to ' + nextTheme + ' theme to access ' + tooltipLabel;
+        anchor.setAttribute('title', tooltip);
+        anchor.setAttribute('aria-label', tooltip);
+      } else {
+        anchor.removeAttribute('title');
+        anchor.removeAttribute('aria-label');
       }
     }
   }

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -31,10 +31,10 @@
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to dark theme to access Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to light theme to access Скачать PDF (светлая тема)">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="light" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to dark theme to access Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to light theme to access Download PDF (EN, light)">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
+
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
+</p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
 <li><strong>Telegram</strong>: <a href="https://t.me/leqqrm">@leqqrm</a></li>
@@ -189,10 +189,10 @@
 </div>
 <footer>
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
-<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="light" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to dark theme to access Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
-<em><a href="../Belyakov_ru_dark.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-variant="dark" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)" data-tooltip="Switch to light theme to access Скачать PDF (светлая тема)">Скачать PDF (тёмная тема)</a></em> \
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="light" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to dark theme to access Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
-<em><a href="../Belyakov_en_dark.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-variant="dark" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)" data-tooltip="Switch to light theme to access Download PDF (EN, light)">Download PDF (EN, dark)</a></em></p>
+<em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
+
+<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
+</p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
@@ -220,62 +220,45 @@
   var root = document.documentElement;
   var key = 'theme';
   function updateResumeLinks(theme){
-    var anchors = document.querySelectorAll('a[data-light-href][data-dark-href][data-variant]');
-    var groups = {};
+    var anchors = document.querySelectorAll('a[data-light-href], a[data-dark-href]');
     for (var i = 0; i < anchors.length; i++) {
       var anchor = anchors[i];
-      var key = (anchor.getAttribute('data-light-href') || '') + '|' + (anchor.getAttribute('data-dark-href') || '');
-      if (!groups[key]) {
-        groups[key] = [];
+      var lightHref = anchor.getAttribute('data-light-href');
+      var darkHref = anchor.getAttribute('data-dark-href');
+      var lightLabel = anchor.getAttribute('data-light-label');
+      var darkLabel = anchor.getAttribute('data-dark-label');
+      var hasLight = !!lightHref;
+      var hasDark = !!darkHref;
+
+      var targetHref = theme === 'dark' && hasDark ? darkHref : lightHref || darkHref;
+      if (!targetHref && hasDark) {
+        targetHref = darkHref;
       }
-      groups[key].push(anchor);
-    }
-    for (var key in groups) {
-      if (!Object.prototype.hasOwnProperty.call(groups, key)) continue;
-      var list = groups[key];
-      var hasLight = false;
-      var hasDark = false;
-      for (var j = 0; j < list.length; j++) {
-        var variantValue = list[j].getAttribute('data-variant');
-        if (variantValue === 'light') {
-          hasLight = true;
-        } else if (variantValue === 'dark') {
-          hasDark = true;
-        }
+      if (targetHref) {
+        anchor.setAttribute('href', targetHref);
       }
-      var shouldToggle = hasLight && hasDark;
-      for (var j = 0; j < list.length; j++) {
-        var anchor = list[j];
-        var variant = anchor.getAttribute('data-variant');
-        var target = theme === 'dark' ? anchor.getAttribute('data-dark-href') : anchor.getAttribute('data-light-href');
-        if (!target) {
-          target = anchor.getAttribute('data-light-href') || anchor.getAttribute('data-dark-href');
-        }
-        if (target) {
-          anchor.setAttribute('href', target);
-        }
-        var label = theme === 'dark' ? anchor.getAttribute('data-dark-label') : anchor.getAttribute('data-light-label');
-        if (label) {
-          anchor.textContent = label;
-        }
-        var tooltip = anchor.getAttribute('data-tooltip');
-        if (tooltip) {
-          anchor.setAttribute('title', tooltip);
-          anchor.setAttribute('aria-label', tooltip);
-        } else {
-          anchor.removeAttribute('title');
-          anchor.removeAttribute('aria-label');
-        }
-        var parent = anchor.parentElement;
-        var displayTarget = anchor;
-        if (parent && parent.tagName && parent.tagName.toLowerCase() === 'em') {
-          displayTarget = parent;
-        }
-        if (shouldToggle && variant && variant !== theme) {
-          displayTarget.style.display = 'none';
-        } else {
-          displayTarget.style.display = '';
-        }
+
+      var label;
+      if (theme === 'dark' && hasDark) {
+        label = darkLabel || lightLabel;
+      } else if (theme === 'dark') {
+        label = lightLabel || darkLabel;
+      } else {
+        label = lightLabel || darkLabel;
+      }
+      if (label) {
+        anchor.textContent = label;
+      }
+
+      if (hasLight && hasDark) {
+        var nextTheme = theme === 'dark' ? 'light' : 'dark';
+        var tooltipLabel = theme === 'dark' ? (lightLabel || 'Light PDF') : (darkLabel || 'Dark PDF');
+        var tooltip = 'Switch to ' + nextTheme + ' theme to access ' + tooltipLabel;
+        anchor.setAttribute('title', tooltip);
+        anchor.setAttribute('aria-label', tooltip);
+      } else {
+        anchor.removeAttribute('title');
+        anchor.removeAttribute('aria-label');
       }
     }
   }


### PR DESCRIPTION
## Summary
- collapse light and dark resume anchors into a single server-rendered element with shared metadata
- update the Handlebars template script to retarget link labels and tooltips for the new structure
- refresh HTML fixtures and expectations to cover the unified anchor shape and placeholders
- Avatar: Rust Tech Lead — selected to steer the architectural refactor of theme-aware resume links

## Testing
- `cargo fmt --manifest-path sitegen/Cargo.toml --all`
- `cargo check --manifest-path sitegen/Cargo.toml`
- `cargo clippy --manifest-path sitegen/Cargo.toml --all-targets`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `cargo machete` (from sitegen)


------
https://chatgpt.com/codex/tasks/task_e_68d0f9d73cb483328202b0a8095646e0