### PR TITLE
Remove cross-language resume PDF links

### DIFF
--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -2,8 +2,6 @@
 *[Link to Russian version](../ru/CV_RU.MD)* \\
 *[Light PDF](https://qqrm.github.io/CV/Belyakov_en_light.pdf)* \\
 *[Dark PDF](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)* \\
-*[Light Russian PDF](https://qqrm.github.io/CV/Belyakov_ru_light.pdf)* \\
-*[Dark Russian PDF](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/profiles/cv/en/CV_EM.MD
+++ b/profiles/cv/en/CV_EM.MD
@@ -2,8 +2,6 @@
 *[Link to Russian version](../ru/CV_EM_RU.MD)* \\
 *[Light PDF](https://qqrm.github.io/CV/Belyakov_em_en_light.pdf)* \\
 *[Dark PDF](https://qqrm.github.io/CV/Belyakov_em_en_dark.pdf)* \\
-*[Light Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru_light.pdf)* \\
-*[Dark Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru_dark.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/profiles/cv/ru/CV_EM_RU.MD
+++ b/profiles/cv/ru/CV_EM_RU.MD
@@ -2,8 +2,6 @@
 *[Ссылка на английскую версию](../en/CV_EM.MD)* \\
 *[Скачать PDF (светлая тема)](https://qqrm.github.io/CV/Belyakov_em_ru_light.pdf)* \\
 *[Скачать PDF (тёмная тема)](https://qqrm.github.io/CV/Belyakov_em_ru_dark.pdf)* \\
-*[Download PDF (EN, light)](https://qqrm.github.io/CV/Belyakov_em_en_light.pdf)* \\
-*[Download PDF (EN, dark)](https://qqrm.github.io/CV/Belyakov_em_en_dark.pdf)*
 
 - **Телефон:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/profiles/cv/ru/CV_RU.MD
+++ b/profiles/cv/ru/CV_RU.MD
@@ -2,8 +2,6 @@
 *[Ссылка на английскую версию](../en/CV.MD)* \\
 *[Скачать PDF (светлая тема)](https://qqrm.github.io/CV/Belyakov_ru_light.pdf)* \\
 *[Скачать PDF (тёмная тема)](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)* \\
-*[Download PDF (EN, light)](https://qqrm.github.io/CV/Belyakov_en_light.pdf)* \\
-*[Download PDF (EN, dark)](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)*
 
 - **Телефон**: +7 (911) 261-70-72
 - **Telegram**: [@leqqrm](https://t.me/leqqrm)

--- a/profiles/resume/en/RESUME_EM.MD
+++ b/profiles/resume/en/RESUME_EM.MD
@@ -2,8 +2,6 @@
 *[Link to Russian version](../ru/RESUME_EM_RU.MD)* \\
 *[Light PDF](https://qqrm.github.io/CV/Belyakov_em_en_light.pdf)* \\
 *[Dark PDF](https://qqrm.github.io/CV/Belyakov_em_en_dark.pdf)* \\
-*[Light Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru_light.pdf)* \\
-*[Dark Russian PDF](https://qqrm.github.io/CV/Belyakov_em_ru_dark.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/profiles/resume/ru/RESUME_EM_RU.MD
+++ b/profiles/resume/ru/RESUME_EM_RU.MD
@@ -2,8 +2,6 @@
 *[Ссылка на английскую версию](../en/RESUME_EM.MD)* \\
 *[Скачать PDF (светлая тема)](https://qqrm.github.io/CV/Belyakov_em_ru_light.pdf)* \\
 *[Скачать PDF (тёмная тема)](https://qqrm.github.io/CV/Belyakov_em_ru_dark.pdf)* \\
-*[Download PDF (EN, light)](https://qqrm.github.io/CV/Belyakov_em_en_light.pdf)* \\
-*[Download PDF (EN, dark)](https://qqrm.github.io/CV/Belyakov_em_en_dark.pdf)*
 
 - **Телефон:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -32,8 +32,6 @@
 
 <p><em><a href="ru/">Link to Russian version</a></em> \
 <em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Light PDF" data-dark-label="Dark PDF">Light PDF</a></em> \
-
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF">Light Russian PDF</a></em> \
 </p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
@@ -195,8 +193,6 @@
 <footer>
 <p><em><a href="ru/">Link to Russian version</a></em> \
 <em><a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Light PDF" data-dark-label="Dark PDF">Light PDF</a></em> \
-
-<em><a href="Belyakov_ru_light.pdf" data-light-href="Belyakov_ru_light.pdf" data-dark-href="Belyakov_ru_dark.pdf" data-light-label="Light Russian PDF" data-dark-label="Dark Russian PDF">Light Russian PDF</a></em> \
 </p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -32,8 +32,6 @@
 
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
 <em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
-
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
 </p>
 <ul>
 <li><strong>Телефон</strong>: +7 (911) 261-70-72</li>
@@ -190,8 +188,6 @@
 <footer>
 <p><em><a href="../">Ссылка на английскую версию</a></em> \
 <em><a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF (светлая тема)" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF (светлая тема)</a></em> \
-
-<em><a href="../Belyakov_en_light.pdf" data-light-href="../Belyakov_en_light.pdf" data-dark-href="../Belyakov_en_dark.pdf" data-light-label="Download PDF (EN, light)" data-dark-label="Download PDF (EN, dark)">Download PDF (EN, light)</a></em> \
 </p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">

--- a/sitegen/tests/generate.rs
+++ b/sitegen/tests/generate.rs
@@ -118,6 +118,22 @@ fn assert_pdf_link_attrs(html: &str, light: &str, dark: &str) {
     }
 }
 
+fn assert_no_pdf_link_attrs(html: &str, light: &str, dark: &str) {
+    let document = Html::parse_document(html);
+    let selector =
+        Selector::parse("a[data-light-href], a[data-dark-href]").expect("valid selector");
+    let has_match = document.select(&selector).any(|node| {
+        let element = node.value();
+        element.attr("data-light-href") == Some(light)
+            && element.attr("data-dark-href") == Some(dark)
+    });
+
+    assert!(
+        !has_match,
+        "unexpected anchor with light='{light}' and dark='{dark}'"
+    );
+}
+
 #[test]
 #[serial_test::serial]
 fn generates_expected_dist() {
@@ -227,7 +243,7 @@ fn generates_expected_dist() {
         "Belyakov_en_light.pdf",
         "Belyakov_en_dark.pdf",
     );
-    assert_pdf_link_attrs(
+    assert_no_pdf_link_attrs(
         &index_actual,
         "Belyakov_ru_light.pdf",
         "Belyakov_ru_dark.pdf",
@@ -237,7 +253,7 @@ fn generates_expected_dist() {
         "../Belyakov_ru_light.pdf",
         "../Belyakov_ru_dark.pdf",
     );
-    assert_pdf_link_attrs(
+    assert_no_pdf_link_attrs(
         &index_ru_actual,
         "../Belyakov_en_light.pdf",
         "../Belyakov_en_dark.pdf",
@@ -277,7 +293,7 @@ fn generates_expected_dist() {
         assert_pdf_link_attrs(&en_page, &en_light, &en_dark);
         let ru_light = format!("../Belyakov_{}_ru_light.pdf", slug);
         let ru_dark = format!("../Belyakov_{}_ru_dark.pdf", slug);
-        assert_pdf_link_attrs(&en_page, &ru_light, &ru_dark);
+        assert_no_pdf_link_attrs(&en_page, &ru_light, &ru_dark);
 
         let ru_path = role_dir.join("ru").join("index.html");
         assert!(ru_path.exists(), "missing {}/ru/index.html", slug);
@@ -287,7 +303,7 @@ fn generates_expected_dist() {
         assert_pdf_link_attrs(&ru_page, &ru_ru_light, &ru_ru_dark);
         let ru_en_light = format!("../../Belyakov_{}_en_light.pdf", slug);
         let ru_en_dark = format!("../../Belyakov_{}_en_dark.pdf", slug);
-        assert_pdf_link_attrs(&ru_page, &ru_en_light, &ru_en_dark);
+        assert_no_pdf_link_attrs(&ru_page, &ru_en_light, &ru_en_dark);
     }
 
     for slug in roles.keys() {
@@ -301,7 +317,7 @@ fn generates_expected_dist() {
         assert_pdf_link_attrs(&en_page, &resume_en_light, &resume_en_dark);
         let resume_ru_light = format!("../../Belyakov_{}_ru_light.pdf", slug);
         let resume_ru_dark = format!("../../Belyakov_{}_ru_dark.pdf", slug);
-        assert_pdf_link_attrs(&en_page, &resume_ru_light, &resume_ru_dark);
+        assert_no_pdf_link_attrs(&en_page, &resume_ru_light, &resume_ru_dark);
 
         let ru_path = resume_dir.join("ru").join("index.html");
         assert!(ru_path.exists(), "missing resume/{}/ru/index.html", slug);
@@ -312,7 +328,7 @@ fn generates_expected_dist() {
         assert_pdf_link_attrs(&ru_page, &resume_ru_ru_light, &resume_ru_ru_dark);
         let resume_ru_en_light = format!("../../../Belyakov_{}_en_light.pdf", slug);
         let resume_ru_en_dark = format!("../../../Belyakov_{}_en_dark.pdf", slug);
-        assert_pdf_link_attrs(&ru_page, &resume_ru_en_light, &resume_ru_en_dark);
+        assert_no_pdf_link_attrs(&ru_page, &resume_ru_en_light, &resume_ru_en_dark);
     }
 
     fs::remove_dir_all(&dist).expect("failed to remove dist");


### PR DESCRIPTION
## Summary
- remove links to Russian PDFs from English CV and resume sources and drop English PDFs from Russian sources
- update HTML fixtures to show only language-specific PDF anchors and keep theme toggling intact
- extend generator tests with a helper that asserts the absence of cross-language PDF anchors

## Testing
- `cargo fmt --manifest-path sitegen/Cargo.toml --all`
- `cargo check --manifest-path sitegen/Cargo.toml --tests --benches`
- `cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path sitegen/Cargo.toml`
- `(cd sitegen && cargo machete)`

## Avatar
- Senior Rust Developer — selected to adjust Rust-based generators and tests for the resume site.


------
https://chatgpt.com/codex/tasks/task_e_68d13423adb4833280778c413487da16