### PR TITLE
Simplify CV narrative and refresh fixtures

### DIFF
--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -1,7 +1,8 @@
 # Alexey Leonidovich Belyakov
-*[Link to Russian version](../ru/CV_RU.MD)* \\
-*[Light PDF](https://qqrm.github.io/CV/Belyakov_en_light.pdf)* \\
-*[Dark PDF](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)* \\
+*[Link to Russian version](../ru/CV_RU.MD)*
+
+*[Download light PDF](https://qqrm.github.io/CV/Belyakov_en_light.pdf)*
+*[Download dark PDF](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)*
 
 - **Phone:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)
@@ -9,15 +10,13 @@
 - **Location:** Remote, full-time availability
 
 ## Executive Profile
-Hands-on engineering leader and DevOps advocate who scales cross-functional teams, delivers complex migration programs, and keeps executives informed with clear metrics. Comfortable driving architectural alignment, people development, release governance, and budget discipline while maintaining a transparent delivery cadence.
+Engineering leader who ships platform migrations without derailing teams or budgets. Keeps stakeholders aligned with clear metrics, steady releases, and direct communication grounded in the work being delivered.
 
 ## Core Strengths
-- Roadmap ownership across multiple teams and workstreams.
-- Transparent KPI/OKR design, tracking, and stakeholder reporting.
-- Budgeting, staffing, and vendor coordination for hybrid on-prem/cloud setups.
-- Team development through structured mentoring, hiring, and performance reviews.
-- Governance and delivery frameworks that balance velocity with risk control.
-- DevOps strategy, release orchestration, and SRE collaboration.
+- Deliver multi-team roadmaps while keeping migrations on schedule.
+- Pair metrics dashboards with executive updates that stay honest and actionable.
+- Hire, coach, and retain engineers until they are ready to lead their own teams.
+- Build release and incident routines that let teams move fast without burning out.
 
 ## Work Experience
 
@@ -25,40 +24,32 @@ Hands-on engineering leader and DevOps advocate who scales cross-functional team
 *March 2023 – Present*
 
 **Leadership & Delivery**
-- Lead a 25-person program replacing SAP workflows with a Rust-based microservices stack.
-- Coordinate backend, QA, analytics, and DevOps leads to keep multi-team milestones on schedule.
-- Balance roadmap scope against migration budgets and quarterly goals, surfacing risks early.
-- Established async and personal sprint planning that raised sprint productivity by ~15% and predictability by ~25%.
-- Chaired a release board aligning QA sign-offs, SAST policies, and deployment readiness reviews for predictable launches.
+- Lead a 25-person program replacing SAP workflows with a Rust microservices stack while keeping quarterly goals intact.
+- Coordinate backend, QA, analytics, and DevOps leads so roadmap and budget decisions stay transparent.
+- Introduced async and personal sprint planning that lifted productivity by ~15% and predictability by ~25%.
+- Ran a lightweight release board that aligned QA sign-offs, SAST policies, and deployment readiness checks.
 
 **Tech Stack & Tooling**
-- Languages & frameworks: Rust (Tokio, Actix Web, Axum, tonic), Go, Python, TypeScript, React, Node.js, GraphQL, gRPC, REST, OpenAPI, AsyncAPI.
-- Data & messaging: PostgreSQL, MySQL, ClickHouse, MongoDB, Redis, Tarantool, Apache Kafka, RabbitMQ, NATS, Apache Pulsar, Debezium, ElasticSearch, OpenSearch, MinIO/S3.
-- Cloud & infrastructure: Kubernetes, Docker, containerd, AWS (EKS, ECS, Lambda, CloudWatch), GCP (GKE, Cloud Run, Pub/Sub), Azure (AKS, Functions), HashiCorp Vault, Consul, Nomad, Istio, Linkerd, Envoy, Service Mesh Interface.
-- IaC & automation: Terraform, Pulumi, Helm, Kustomize, Argo CD, FluxCD, Ansible, Packer, Argo Workflows, GitOps pipelines, Crossplane, Renovate, Dependabot.
-- CI/CD & security: GitLab CI, GitHub Actions, Jenkins, TeamCity, Buildkite, SonarQube, Snyk, Trivy, Clair, Harbor, HashiCorp Boundary, Open Policy Agent, Kyverno, Falco, Vault Secrets Engines.
-- Observability & SRE: Prometheus, Grafana, Loki, Tempo, Alertmanager, OpenTelemetry, Jaeger, Zipkin, Kibana, Datadog, New Relic, Splunk, ELK, Sentry, PagerDuty, Opsgenie, Chaos Mesh.
+- Rust (Tokio, Actix Web, Axum, tonic) with supporting Go, Python, and TypeScript services.
+- PostgreSQL, ClickHouse, Redis, Kafka, and NATS for data movement and storage.
+- Kubernetes on AWS, GCP, and Azure with Terraform, Argo CD, and GitOps automation.
+- GitLab CI, GitHub Actions, SonarQube, Snyk, and Prometheus/Grafana for delivery and reliability guardrails.
 
 **People & Governance**
-- Expanded the backend team from 5 to 12 developers while reducing onboarding time by ~30%.
-- Retained 90% of hires after the first year by pairing growth plans with consistent feedback loops.
-- Mentored three engineers to senior roles using a competency matrix and targeted coaching.
-- Integrated static analysis (Clippy, cargo-audit, SonarQube) and internal package distribution to satisfy compliance requirements.
-- Evangelized DevOps practices across teams, pairing incident reviews with automation backlogs and driving CI/CD adoption.
+- Grew the backend team from 5 to 12 engineers while trimming onboarding time by ~30%.
+- Retained 90% of hires after the first year with growth plans and recurring feedback.
+- Mentored three engineers into senior roles and rolled out static analysis and internal package delivery to meet compliance goals.
 
 ### Rust Team Lead @ Solcery | March 2022 – March 2023
-- Managed a 4-person Rust team building a DAO-ready blockchain database on Solana.
-- Translated product goals into sprint plans, release scopes, and technical specifications.
-- Reduced code review time by ~40% via review policies, pairing, and test automation.
-- Implemented schema versioning and migration practices that cut maintenance overhead and simplified onboarding.
-- Introduced distributed tracing, canary deployments, and release health dashboards for smart-contract delivery.
+- Managed a 4-person Rust team building a blockchain-ready database on Solana.
+- Turned product goals into sprint plans, release scopes, and clear specs.
+- Cut code review time by ~40% through review policies, pairing, and test automation.
+- Added schema versioning, migrations, distributed tracing, and canary releases to keep delivery safe.
 
 **Tech Stack & Tooling**
-- Protocols & runtimes: Rust (async/await, Tokio, Actix, Axum), Anchor, Solana SDK, WebAssembly, Web3.js, TypeScript, React, Next.js, Node.js, GraphQL, gRPC, REST.
-- Data & storage: PostgreSQL, FoundationDB, RocksDB, IPFS, Redis, ClickHouse, TimescaleDB, Apache Arrow, Delta Lake, Parquet, Apache Spark for analytics backfills.
-- Blockchain & cryptography: Solana Programs, Metaplex, SPL tokens, BPF toolchain, zero-knowledge circuits (Halo2, zk-SNARKs), Ledger hardware wallets, HSM integration, secure enclaves (Intel SGX).
-- DevOps & automation: Docker, Kubernetes, k3s, Terraform, Helm, GitHub Actions, GitLab CI, CircleCI, Argo CD, Argo Rollouts, GitOps, HashiCorp Vault, Ansible, Consul Template, Nomad, HashiCorp Packer.
-- Observability & QA: Prometheus, Grafana, Loki, Tempo, OpenTelemetry, Jaeger, Kibana, ElasticSearch, Datadog, Chaos Monkey, k6, Gatling, pytest, cargo-nextest, cargo-tarpaulin.
+- Rust (async/await, Tokio, Actix, Axum) with Anchor and Solana SDK on the runtime side.
+- PostgreSQL, FoundationDB, RocksDB, and IPFS for storage, backed by Terraform-managed Kubernetes and GitOps.
+- Prometheus, Grafana, OpenTelemetry, and k6 for tracing, observability, and performance testing.
 
 ### Senior Rust Developer @ Kaspersky Lab | May 2021 – March 2022
 - Coordinated with product, QA, and operations while maintaining a blockchain-based voting platform.
@@ -67,46 +58,27 @@ Hands-on engineering leader and DevOps advocate who scales cross-functional team
 - Hardened cryptographic modules and containerized workloads for secure ballot storage and auditability.
 
 **Tech Stack & Tooling**
-- Backend & services: Rust (Actix Web, Axum, Hyper, tonic), C++, Python, gRPC, GraphQL, REST, WebSockets, Protocol Buffers, FlatBuffers, Apache Thrift.
-- Security & cryptography: PKCS#11, HSM, TLS 1.3, mTLS, OAuth 2.0, OpenID Connect, JWT, hardware-backed key storage, FIPS 140-2 compliance, YubiKey.
-- Data & infrastructure: PostgreSQL, Oracle, MS SQL Server, Redis, Apache Cassandra, Apache Kafka, RabbitMQ, HashiCorp Vault, Consul, Nomad, Docker, Kubernetes, OpenShift, VMware Tanzu, Ceph.
-- Testing & reliability: GitLab CI/CD, TeamCity, Jenkins, Azure DevOps, Bazel, Conan, Artifactory, SonarQube, Fortify, Checkmarx, Veracode, Git Secrets, OWASP ZAP, Burp Suite, Prometheus, Grafana, ELK.
+- Rust (Actix Web, Axum, Hyper, tonic) alongside C++ and Python services exposed through gRPC and GraphQL.
+- Vault-backed PostgreSQL and Kafka deployments running on Kubernetes and OpenShift.
+- GitLab CI/CD, Jenkins, SonarQube, and Fortify reinforcing secure delivery.
 
-## Operating Rhythm & Governance
-- Weekly portfolio reviews with business stakeholders, surfacing KPI movements and budget status.
-- Quarterly planning rituals that align product, engineering, and operations on priorities and capacity.
-- Continuous improvement loops—retrospectives, survey feedback, and actionable experiments.
-- Data-informed reporting through Jira dashboards, Confluence scorecards, and lightweight memos.
-
-## Results & Impact
+## Results & Operating Rhythm
 - Delivery stayed within 5% of budget during a 6-month team expansion.
 - Bug backlog shrank by ~30% after reinforcing QA, code reviews, and release gates.
-- Maintained ~90% adherence to quarterly KPIs despite scope churn and infrastructure constraints.
+- Maintain weekly stakeholder reviews, quarterly planning, and continuous improvement loops that surface risks early.
+- Reporting relies on concise Jira dashboards, Confluence scorecards, and memos that map decisions to measurable impact.
 
-## Tools & Practices
-- Planning: Jira Advanced Roadmaps, Notion roadmaps, Confluence specs, Linear, Shortcut, Productboard, Aha!, ClickUp, Miro, FigJam.
-- Delivery: Scrum, Kanban hybrids, SAFe, LeSS, Shape Up, async updates, definition-of-done enforcement, dual-track discovery, OKR cadences.
-- Quality: GitLab CI/CD, GitHub Actions, CircleCI, Buildkite, Argo Rollouts, feature flags, blue/green deployments, chaos engineering, risk registers, static analysis gates.
-- People: Competency matrices, growth plans, structured 1:1s, skip-level feedback, calibration sessions, succession planning, mentoring guilds.
-- Architecture & DevOps: Domain-driven design, event sourcing, CQRS, hexagonal architecture, microservices, serverless, container orchestration, service mesh, edge computing, zero-trust networking.
-
-## Technical Keywords
-- Rust, Go, Python, TypeScript, JavaScript, C++, Solidity, WebAssembly, Solana, Anchor, Substrate, Cosmos SDK, GraphQL, gRPC, REST, SOAP, WebSockets, MQTT, OPC UA.
-- PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, ClickHouse, Snowflake, BigQuery, Redshift, MongoDB, Couchbase, Cassandra, ScyllaDB, Neo4j, JanusGraph, Dgraph, Elasticsearch.
-- Kafka, RabbitMQ, ActiveMQ, IBM MQ, NATS, Pulsar, AWS Kinesis, Google Pub/Sub, Azure Event Hubs, Debezium, Change Data Capture, Apache Flink, Spark Streaming.
-- Docker, Podman, containerd, Kubernetes, OpenShift, Nomad, HashiCorp Vault, Consul, Istio, Linkerd, Envoy, Cilium, Calico, MetalLB, Knative, OpenFaaS.
-- Terraform, Pulumi, Crossplane, AWS CloudFormation, Azure Bicep, Google Deployment Manager, Ansible, Chef, Puppet, SaltStack, Packer, Vagrant.
-- AWS (EKS, ECS, Lambda, EC2, S3, DynamoDB, RDS, Aurora, API Gateway), GCP (GKE, Cloud Run, Cloud Functions, Spanner, Bigtable), Azure (AKS, Functions, Cosmos DB, Event Grid), DigitalOcean, Hetzner Cloud.
-- GitLab CI, GitHub Actions, Jenkins, TeamCity, Azure DevOps, CircleCI, Buildkite, Travis CI, Codefresh, Argo CD, FluxCD, Spinnaker, Harness, Atlantis.
-- Prometheus, Grafana, Loki, Tempo, Cortex, Thanos, OpenTelemetry, Jaeger, Zipkin, Kibana, Elastic Stack, Datadog, New Relic, Splunk, Sentry, Honeycomb, PagerDuty, Opsgenie, VictorOps.
-- Security & compliance: SonarQube, Snyk, Trivy, Clair, Aqua, Prisma Cloud, HashiCorp Boundary, Vault, Open Policy Agent, Kyverno, Falco, Istio mTLS, SPIFFE/SPIRE, Vault Secrets Engines, CIS Benchmarks, ISO 27001.
-- Collaboration: Jira, Confluence, Notion, Google Workspace, Microsoft 365, Slack, Mattermost, Zoom, Loom, Git, GitHub, GitLab, Bitbucket, Phabricator.
+## Tooling Snapshot
+- Daily languages: Rust, Go, Python, and TypeScript with PostgreSQL, ClickHouse, and Redis at the core.
+- Platform: Kubernetes, Terraform, and Argo CD across AWS, GCP, and Azure with GitOps workflows.
+- Quality gates: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus, and Grafana for delivery, security, and observability.
+- Collaboration stack: Jira, Confluence, Notion, Slack, GitHub, and GitLab.
 
 ## What I Offer
-- Executive-ready communication paired with credible technical depth.
-- Ability to bootstrap or mature engineering processes without slowing delivery.
-- Proven record of scaling teams, mentoring leaders, and maintaining morale through change.
+- Straightforward communication backed by hands-on technical depth.
+- Launch or tune engineering processes without slowing the team.
+- Scale teams, mentor new leads, and keep morale steady through change.
 
 ## Additional Information
 - [Full CV](https://qqrm.github.io/CV/)
-- Full CV PDFs: [light](https://qqrm.github.io/CV/Belyakov_en_light.pdf) · [dark](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)
+- Download PDF: [light theme](https://qqrm.github.io/CV/Belyakov_en_light.pdf) · [dark theme](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)

--- a/profiles/cv/ru/CV_RU.MD
+++ b/profiles/cv/ru/CV_RU.MD
@@ -1,7 +1,8 @@
 # Алексей Леонидович Беляков
-*[Ссылка на английскую версию](../en/CV.MD)* \\
-*[Скачать PDF (светлая тема)](https://qqrm.github.io/CV/Belyakov_ru_light.pdf)* \\
-*[Скачать PDF (тёмная тема)](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)* \\
+*[Ссылка на английскую версию](../en/CV.MD)*
+
+*[Скачать PDF (светлая тема)](https://qqrm.github.io/CV/Belyakov_ru_light.pdf)*
+*[Скачать PDF (тёмная тема)](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)*
 
 - **Телефон:** +7 (911) 261-70-72
 - **Telegram:** [@leqqrm](https://t.me/leqqrm)
@@ -9,15 +10,13 @@
 - **Формат работы:** Удалённо, полный день
 
 ## Профиль руководителя разработки
-Практикующий инженерный лидер и приверженец DevOps, который масштабирует кросс-функциональные команды, ведёт сложные программы миграции и обеспечивает прозрачность метрик для руководства. Умеет выстраивать архитектурное единство, развивать людей, управлять релизами и держать бюджет под контролем без просадки по скорости поставки.
+Руководитель разработки, который проводит миграции платформ без срывов по срокам и бюджету. Держу стейкхолдеров в курсе через понятные метрики, предсказуемые релизы и прямую коммуникацию на языке продукта и инженеров.
 
 ## Ключевые сильные стороны
-- Ведение дорожных карт для нескольких команд и направлений.
-- Проработка KPI/OKR, прозрачный трекинг и отчётность для стейкхолдеров.
-- Планирование бюджета, набор и взаимодействие с подрядчиками в гибридной инфраструктуре.
-- Развитие специалистов через менторство, найм и регулярные performance review.
-- Системы управления доставкой, которые балансируют скорость и контроль рисков.
-- DevOps-стратегия, релизное управление и взаимодействие с SRE.
+- Веду дорожные карты из нескольких команд, сохраняя темп миграций.
+- Даю руководству честные апдейты на основе метрик и рабочих дашбордов.
+- Набираю, развиваю и удерживаю инженеров, пока они не готовы вести команды.
+- Выстраиваю релизные и инцидентные процессы, которые защищают скорость и людей.
 
 ## Опыт работы
 
@@ -25,88 +24,61 @@
 *март 2023 – настоящее время*
 
 **Лидерство и поставка**
-- Руководил программой из 25 человек по замене SAP на микросервисы на Rust.
-- Согласовывал работу лидов бэкенда, QA, аналитики и DevOps, удерживая единый график релизов.
-- Балансировал дорожную карту, бюджет миграции и квартальные цели, заранее подсвечивая риски.
-- Внедрил асинхронное и персональное планирование спринтов, что повысило продуктивность примерно на 15% и предсказуемость примерно на 25%.
-- Возглавил релизный комитет, синхронизировав QA-аппрувы, SAST-политику и готовность инфраструктуры для предсказуемых релизов.
+- Руководил программой из 25 человек по замене SAP на Rust-микросервисы без потери квартальных целей.
+- Координировал лидов бэкенда, QA, аналитики и DevOps, чтобы решения по дорожной карте и бюджету были прозрачными.
+- Внедрил асинхронное и персональное планирование спринтов, подняв продуктивность примерно на 15% и предсказуемость примерно на 25%.
+- Вёл компактный релизный совет, выравнивая QA-аппрувы, SAST-политику и готовность инфраструктуры.
 
 **Технологии и инструменты**
-- Языки и фреймворки: Rust (Tokio, Actix Web, Axum, tonic), Go, Python, TypeScript, React, Node.js, GraphQL, gRPC, REST, OpenAPI, AsyncAPI.
-- Данные и интеграции: PostgreSQL, MySQL, ClickHouse, MongoDB, Redis, Tarantool, Apache Kafka, RabbitMQ, NATS, Apache Pulsar, Debezium, ElasticSearch, OpenSearch, MinIO/S3.
-- Облако и инфраструктура: Kubernetes, Docker, containerd, AWS (EKS, ECS, Lambda, CloudWatch), GCP (GKE, Cloud Run, Pub/Sub), Azure (AKS, Functions), HashiCorp Vault, Consul, Nomad, Istio, Linkerd, Envoy, Service Mesh Interface.
-- IaC и автоматизация: Terraform, Pulumi, Helm, Kustomize, Argo CD, FluxCD, Ansible, Packer, Argo Workflows, GitOps-пайплайны, Crossplane, Renovate, Dependabot.
-- CI/CD и безопасность: GitLab CI, GitHub Actions, Jenkins, TeamCity, Buildkite, SonarQube, Snyk, Trivy, Clair, Harbor, HashiCorp Boundary, Open Policy Agent, Kyverno, Falco, Vault Secrets Engines.
-- Наблюдаемость и SRE: Prometheus, Grafana, Loki, Tempo, Alertmanager, OpenTelemetry, Jaeger, Zipkin, Kibana, Datadog, New Relic, Splunk, ELK, Sentry, PagerDuty, Opsgenie, Chaos Mesh.
+- Rust (Tokio, Actix Web, Axum, tonic) и поддерживающие сервисы на Go, Python и TypeScript.
+- PostgreSQL, ClickHouse, Redis, Kafka и NATS для хранения и обмена данными.
+- Kubernetes на AWS, GCP и Azure с автоматизацией через Terraform, Argo CD и GitOps.
+- GitLab CI, GitHub Actions, SonarQube, Snyk и Prometheus/Grafana как основа качества и надёжности.
 
 **Люди и управление**
-- Увеличил бэкенд-команду с 5 до 12 разработчиков, сократив онбординг примерно на 30%.
-- Сохранил 90% новых сотрудников после первого года за счёт планов развития и регулярной обратной связи.
-- Вырастил трёх инженеров до уровня senior по матрице компетенций и адресному коучингу.
-- Включил статический анализ (Clippy, cargo-audit, SonarQube) и внутренний пакетный репозиторий для соответствия требованиям ИБ.
-- Популяризировал DevOps-подходы: совмещал разбор инцидентов с автоматизацией задач и масштабровал CI/CD практики на команды.
+- Вырастил бэкенд с 5 до 12 инженеров, сократив онбординг примерно на 30%.
+- Удержал 90% наймов после первого года благодаря планам развития и регулярной обратной связи.
+- Менторил трёх инженеров до senior-уровня и внедрил статанализ и внутреннюю доставку пакетов под требования ИБ.
 
 ### Rust Team Lead @ Solcery | март 2022 – март 2023
-- Управлял командой из 4 Rust-разработчиков, создающих блокчейн-базу данных для DAO на Solana.
-- Переводил продуктовые цели в план спринтов, объём релизов и технические спецификации.
-- Сократил среднее время код-ревью примерно на 40% за счёт правил, парного программирования и автотестов.
-- Внедрил версионирование схем и миграции, что снизило издержки поддержки и ускорило адаптацию новичков.
-- Добавил распределённый трейсинг, канареечные релизы и панели здоровья смарт-контрактов.
+- Управлял командой из 4 Rust-разработчиков, создающих блокчейн-базу данных под Solana.
+- Переводил продуктовые цели в планы спринтов, объём релизов и понятные спецификации.
+- Сократил код-ревью примерно на 40% за счёт правил, парного программирования и автотестов.
+- Добавил версионирование схем, миграции, распределённый трейсинг и канареечные релизы.
 
 **Технологии и инструменты**
-- Протоколы и рантаймы: Rust (async/await, Tokio, Actix, Axum), Anchor, Solana SDK, WebAssembly, Web3.js, TypeScript, React, Next.js, Node.js, GraphQL, gRPC, REST.
-- Данные и хранение: PostgreSQL, FoundationDB, RocksDB, IPFS, Redis, ClickHouse, TimescaleDB, Apache Arrow, Delta Lake, Parquet, Apache Spark для аналитических бэкфилов.
-- Блокчейн и криптография: Solana Programs, Metaplex, SPL tokens, BPF toolchain, zero-knowledge circuits (Halo2, zk-SNARKs), Ledger hardware wallets, HSM, защищённые анклавы (Intel SGX).
-- DevOps и автоматизация: Docker, Kubernetes, k3s, Terraform, Helm, GitHub Actions, GitLab CI, CircleCI, Argo CD, Argo Rollouts, GitOps, HashiCorp Vault, Ansible, Consul Template, Nomad, HashiCorp Packer.
-- Наблюдаемость и QA: Prometheus, Grafana, Loki, Tempo, OpenTelemetry, Jaeger, Kibana, ElasticSearch, Datadog, Chaos Monkey, k6, Gatling, pytest, cargo-nextest, cargo-tarpaulin.
+- Rust (async/await, Tokio, Actix, Axum) с Anchor и Solana SDK.
+- PostgreSQL, FoundationDB, RocksDB и IPFS, развёрнутые на Kubernetes под управлением Terraform и GitOps.
+- Prometheus, Grafana, OpenTelemetry и k6 для трассировки, наблюдаемости и нагрузочного тестирования.
 
 ### Senior Rust Developer @ Kaspersky Lab | май 2021 – март 2022
 - Работал на стыке продукта, QA и операций, поддерживая блокчейн-платформу голосования.
-- Увеличил покрытие тестами примерно до 75%, снизив количество пострелизных инцидентов примерно на 25%.
-- Вёл рефакторинг, упрощающий ввод новых фич и передачу знаний между командами.
+- Увеличил покрытие тестами примерно до 75%, снизив пострелизные инциденты примерно на 25%.
+- Вёл рефакторинг, упрощающий ввод новых фич и обмен знаниями между командами.
 - Усилил криптомодули и контейнеризацию для безопасного хранения бюллетеней и аудита.
 
 **Технологии и инструменты**
-- Бэкенд и сервисы: Rust (Actix Web, Axum, Hyper, tonic), C++, Python, gRPC, GraphQL, REST, WebSockets, Protocol Buffers, FlatBuffers, Apache Thrift.
-- Безопасность и криптография: PKCS#11, HSM, TLS 1.3, mTLS, OAuth 2.0, OpenID Connect, JWT, аппаратное хранение ключей, FIPS 140-2, YubiKey.
-- Данные и инфраструктура: PostgreSQL, Oracle, MS SQL Server, Redis, Apache Cassandra, Apache Kafka, RabbitMQ, HashiCorp Vault, Consul, Nomad, Docker, Kubernetes, OpenShift, VMware Tanzu, Ceph.
-- Тестирование и надёжность: GitLab CI/CD, TeamCity, Jenkins, Azure DevOps, Bazel, Conan, Artifactory, SonarQube, Fortify, Checkmarx, Veracode, Git Secrets, OWASP ZAP, Burp Suite, Prometheus, Grafana, ELK.
+- Rust (Actix Web, Axum, Hyper, tonic) вместе с сервисами на C++ и Python через gRPC и GraphQL.
+- PostgreSQL и Kafka с секретами в Vault, развёрнутые на Kubernetes и OpenShift.
+- GitLab CI/CD, Jenkins, SonarQube и Fortify для безопасной доставки.
 
-## Операционный ритм и управление
-- Еженедельные портфельные ревью с бизнесом: статус KPI, бюджет, риски.
-- Квартальное планирование с выравниванием продуктовой, инженерной и операционной повестки.
-- Постоянное улучшение — ретроспективы, опросы и эксперименты с измеримым эффектом.
-- Отчётность на данных через дашборды Jira, конспекты в Confluence и лаконичные мемо.
+## Результаты и ритм работы
+- Держал доставку в пределах 5% от бюджета во время шестимесячного роста команды.
+- Сократил баг-бэклог примерно на 30% за счёт усиленного QA и контроля релизов.
+- Поддерживаю еженедельные встречи со стейкхолдерами, квартальное планирование и постоянные улучшения, чтобы риски всплывали заранее.
+- Отчётность строю на дашбордах Jira, сводках в Confluence и коротких мемо с измеримыми решениями.
 
-## Результаты
-- Доставка оставалась в пределах 5% от бюджета во время шестимесячного роста команды.
-- Баг-бэклог сократился примерно на 30% благодаря усиленным QA-практикам и контролю релизов.
-- Удерживал примерно 90% выполнения квартальных KPI даже при изменении объёма и ограничениях инфраструктуры.
-
-## Инструменты и практики
-- Планирование: Jira Advanced Roadmaps, дорожные карты в Notion, спецификации в Confluence, Linear, Shortcut, Productboard, Aha!, ClickUp, Miro, FigJam.
-- Доставка: Scrum, гибриды Kanban, SAFe, LeSS, Shape Up, асинхронные апдейты, жёсткий Definition of Done, dual-track discovery, OKR-циклы.
-- Качество: GitLab CI/CD, GitHub Actions, CircleCI, Buildkite, Argo Rollouts, feature flags, blue/green, chaos engineering, матрицы рисков, статический анализ.
-- Люди: матрицы компетенций, планы развития, структурированные 1:1, skip-level обратная связь, калибровочные сессии, succession planning, менторские гильдии.
-- Архитектура и DevOps: Domain-driven design, event sourcing, CQRS, hexagonal architecture, микросервисы, serverless, оркестрация контейнеров, сервис-меш, edge computing, zero-trust.
-
-## Ключевые технологии
-- Rust, Go, Python, TypeScript, JavaScript, C++, Solidity, WebAssembly, Solana, Anchor, Substrate, Cosmos SDK, GraphQL, gRPC, REST, SOAP, WebSockets, MQTT, OPC UA.
-- PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, ClickHouse, Snowflake, BigQuery, Redshift, MongoDB, Couchbase, Cassandra, ScyllaDB, Neo4j, JanusGraph, Dgraph, Elasticsearch.
-- Kafka, RabbitMQ, ActiveMQ, IBM MQ, NATS, Pulsar, AWS Kinesis, Google Pub/Sub, Azure Event Hubs, Debezium, Change Data Capture, Apache Flink, Spark Streaming.
-- Docker, Podman, containerd, Kubernetes, OpenShift, Nomad, HashiCorp Vault, Consul, Istio, Linkerd, Envoy, Cilium, Calico, MetalLB, Knative, OpenFaaS.
-- Terraform, Pulumi, Crossplane, AWS CloudFormation, Azure Bicep, Google Deployment Manager, Ansible, Chef, Puppet, SaltStack, Packer, Vagrant.
-- AWS (EKS, ECS, Lambda, EC2, S3, DynamoDB, RDS, Aurora, API Gateway), GCP (GKE, Cloud Run, Cloud Functions, Spanner, Bigtable), Azure (AKS, Functions, Cosmos DB, Event Grid), DigitalOcean, Hetzner Cloud.
-- GitLab CI, GitHub Actions, Jenkins, TeamCity, Azure DevOps, CircleCI, Buildkite, Travis CI, Codefresh, Argo CD, FluxCD, Spinnaker, Harness, Atlantis.
-- Prometheus, Grafana, Loki, Tempo, Cortex, Thanos, OpenTelemetry, Jaeger, Zipkin, Kibana, Elastic Stack, Datadog, New Relic, Splunk, Sentry, Honeycomb, PagerDuty, Opsgenie, VictorOps.
-- Безопасность и соответствие: SonarQube, Snyk, Trivy, Clair, Aqua, Prisma Cloud, HashiCorp Boundary, Vault, Open Policy Agent, Kyverno, Falco, Istio mTLS, SPIFFE/SPIRE, Vault Secrets Engines, CIS Benchmarks, ISO 27001.
-- Коллаборация: Jira, Confluence, Notion, Google Workspace, Microsoft 365, Slack, Mattermost, Zoom, Loom, Git, GitHub, GitLab, Bitbucket, Phabricator.
+## Технологический профиль
+- Ежедневные языки: Rust, Go, Python и TypeScript с базами PostgreSQL, ClickHouse и Redis.
+- Платформа: Kubernetes, Terraform и Argo CD на AWS, GCP и Azure с GitOps-процессами.
+- Контроль качества: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus и Grafana.
+- Совместная работа: Jira, Confluence, Notion, Slack, GitHub и GitLab.
 
 ## Что предлагаю
-- Понятная коммуникация для руководства и глубокое понимание технических деталей.
-- Умение запускать или усиливать инженерные процессы без просадки по скорости.
-- Доказанный опыт масштабирования команд, развития лидов и поддержания мотивации при изменениях.
+- Простая коммуникация для руководства и глубокое техническое погружение.
+- Умею запускать или усиливать процессы без просадки по скорости команды.
+- Масштабирую команды, развиваю лидов и держу мотивацию в периоды изменений.
 
 ## Дополнительно
 - [Полное CV](https://qqrm.github.io/CV/)
-- Полные PDF-версии CV: [светлая](https://qqrm.github.io/CV/Belyakov_ru_light.pdf) · [тёмная](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)
+- Скачать PDF: [светлая тема](https://qqrm.github.io/CV/Belyakov_ru_light.pdf) · [тёмная тема](https://qqrm.github.io/CV/Belyakov_ru_dark.pdf)

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -29,8 +29,8 @@
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
-<p><em><a href="ru/">Link to Russian version</a></em> \
-
+<p><em><a href="ru/">Link to Russian version</a></em></p>
+<p>
 </p>
 <ul>
 <li><strong>Phone:</strong> +7 (911) 261-70-72</li>
@@ -39,59 +39,49 @@
 <li><strong>Location:</strong> Remote, full-time availability</li>
 </ul>
 <h2>Executive Profile</h2>
-<p>Hands-on engineering leader and DevOps advocate who scales cross-functional teams, delivers complex migration programs, and keeps executives informed with clear metrics. Comfortable driving architectural alignment, people development, release governance, and budget discipline while maintaining a transparent delivery cadence.</p>
+<p>Engineering leader who ships platform migrations without derailing teams or budgets. Keeps stakeholders aligned with clear metrics, steady releases, and direct communication grounded in the work being delivered.</p>
 <h2>Core Strengths</h2>
 <ul>
-<li>Roadmap ownership across multiple teams and workstreams.</li>
-<li>Transparent KPI/OKR design, tracking, and stakeholder reporting.</li>
-<li>Budgeting, staffing, and vendor coordination for hybrid on-prem/cloud setups.</li>
-<li>Team development through structured mentoring, hiring, and performance reviews.</li>
-<li>Governance and delivery frameworks that balance velocity with risk control.</li>
-<li>DevOps strategy, release orchestration, and SRE collaboration.</li>
+<li>Deliver multi-team roadmaps while keeping migrations on schedule.</li>
+<li>Pair metrics dashboards with executive updates that stay honest and actionable.</li>
+<li>Hire, coach, and retain engineers until they are ready to lead their own teams.</li>
+<li>Build release and incident routines that let teams move fast without burning out.</li>
 </ul>
 <h2>Work Experience</h2>
 <h3>Engineering Manager @ Inline Group | March 2023 – Present (DURATION)</h3>
 <p><em>March 2023 – Present</em></p>
 <p><strong>Leadership &amp; Delivery</strong></p>
 <ul>
-<li>Lead a 25-person program replacing SAP workflows with a Rust-based microservices stack.</li>
-<li>Coordinate backend, QA, analytics, and DevOps leads to keep multi-team milestones on schedule.</li>
-<li>Balance roadmap scope against migration budgets and quarterly goals, surfacing risks early.</li>
-<li>Established async and personal sprint planning that raised sprint productivity by ~15% and predictability by ~25%.</li>
-<li>Chaired a release board aligning QA sign-offs, SAST policies, and deployment readiness reviews for predictable launches.</li>
+<li>Lead a 25-person program replacing SAP workflows with a Rust microservices stack while keeping quarterly goals intact.</li>
+<li>Coordinate backend, QA, analytics, and DevOps leads so roadmap and budget decisions stay transparent.</li>
+<li>Introduced async and personal sprint planning that lifted productivity by ~15% and predictability by ~25%.</li>
+<li>Ran a lightweight release board that aligned QA sign-offs, SAST policies, and deployment readiness checks.</li>
 </ul>
 <p><strong>Tech Stack &amp; Tooling</strong></p>
 <ul>
-<li>Languages &amp; frameworks: Rust (Tokio, Actix Web, Axum, tonic), Go, Python, TypeScript, React, Node.js, GraphQL, gRPC, REST, OpenAPI, AsyncAPI.</li>
-<li>Data &amp; messaging: PostgreSQL, MySQL, ClickHouse, MongoDB, Redis, Tarantool, Apache Kafka, RabbitMQ, NATS, Apache Pulsar, Debezium, ElasticSearch, OpenSearch, MinIO/S3.</li>
-<li>Cloud &amp; infrastructure: Kubernetes, Docker, containerd, AWS (EKS, ECS, Lambda, CloudWatch), GCP (GKE, Cloud Run, Pub/Sub), Azure (AKS, Functions), HashiCorp Vault, Consul, Nomad, Istio, Linkerd, Envoy, Service Mesh Interface.</li>
-<li>IaC &amp; automation: Terraform, Pulumi, Helm, Kustomize, Argo CD, FluxCD, Ansible, Packer, Argo Workflows, GitOps pipelines, Crossplane, Renovate, Dependabot.</li>
-<li>CI/CD &amp; security: GitLab CI, GitHub Actions, Jenkins, TeamCity, Buildkite, SonarQube, Snyk, Trivy, Clair, Harbor, HashiCorp Boundary, Open Policy Agent, Kyverno, Falco, Vault Secrets Engines.</li>
-<li>Observability &amp; SRE: Prometheus, Grafana, Loki, Tempo, Alertmanager, OpenTelemetry, Jaeger, Zipkin, Kibana, Datadog, New Relic, Splunk, ELK, Sentry, PagerDuty, Opsgenie, Chaos Mesh.</li>
+<li>Rust (Tokio, Actix Web, Axum, tonic) with supporting Go, Python, and TypeScript services.</li>
+<li>PostgreSQL, ClickHouse, Redis, Kafka, and NATS for data movement and storage.</li>
+<li>Kubernetes on AWS, GCP, and Azure with Terraform, Argo CD, and GitOps automation.</li>
+<li>GitLab CI, GitHub Actions, SonarQube, Snyk, and Prometheus/Grafana for delivery and reliability guardrails.</li>
 </ul>
 <p><strong>People &amp; Governance</strong></p>
 <ul>
-<li>Expanded the backend team from 5 to 12 developers while reducing onboarding time by ~30%.</li>
-<li>Retained 90% of hires after the first year by pairing growth plans with consistent feedback loops.</li>
-<li>Mentored three engineers to senior roles using a competency matrix and targeted coaching.</li>
-<li>Integrated static analysis (Clippy, cargo-audit, SonarQube) and internal package distribution to satisfy compliance requirements.</li>
-<li>Evangelized DevOps practices across teams, pairing incident reviews with automation backlogs and driving CI/CD adoption.</li>
+<li>Grew the backend team from 5 to 12 engineers while trimming onboarding time by ~30%.</li>
+<li>Retained 90% of hires after the first year with growth plans and recurring feedback.</li>
+<li>Mentored three engineers into senior roles and rolled out static analysis and internal package delivery to meet compliance goals.</li>
 </ul>
 <h3>Rust Team Lead @ Solcery | March 2022 – March 2023</h3>
 <ul>
-<li>Managed a 4-person Rust team building a DAO-ready blockchain database on Solana.</li>
-<li>Translated product goals into sprint plans, release scopes, and technical specifications.</li>
-<li>Reduced code review time by ~40% via review policies, pairing, and test automation.</li>
-<li>Implemented schema versioning and migration practices that cut maintenance overhead and simplified onboarding.</li>
-<li>Introduced distributed tracing, canary deployments, and release health dashboards for smart-contract delivery.</li>
+<li>Managed a 4-person Rust team building a blockchain-ready database on Solana.</li>
+<li>Turned product goals into sprint plans, release scopes, and clear specs.</li>
+<li>Cut code review time by ~40% through review policies, pairing, and test automation.</li>
+<li>Added schema versioning, migrations, distributed tracing, and canary releases to keep delivery safe.</li>
 </ul>
 <p><strong>Tech Stack &amp; Tooling</strong></p>
 <ul>
-<li>Protocols &amp; runtimes: Rust (async/await, Tokio, Actix, Axum), Anchor, Solana SDK, WebAssembly, Web3.js, TypeScript, React, Next.js, Node.js, GraphQL, gRPC, REST.</li>
-<li>Data &amp; storage: PostgreSQL, FoundationDB, RocksDB, IPFS, Redis, ClickHouse, TimescaleDB, Apache Arrow, Delta Lake, Parquet, Apache Spark for analytics backfills.</li>
-<li>Blockchain &amp; cryptography: Solana Programs, Metaplex, SPL tokens, BPF toolchain, zero-knowledge circuits (Halo2, zk-SNARKs), Ledger hardware wallets, HSM integration, secure enclaves (Intel SGX).</li>
-<li>DevOps &amp; automation: Docker, Kubernetes, k3s, Terraform, Helm, GitHub Actions, GitLab CI, CircleCI, Argo CD, Argo Rollouts, GitOps, HashiCorp Vault, Ansible, Consul Template, Nomad, HashiCorp Packer.</li>
-<li>Observability &amp; QA: Prometheus, Grafana, Loki, Tempo, OpenTelemetry, Jaeger, Kibana, ElasticSearch, Datadog, Chaos Monkey, k6, Gatling, pytest, cargo-nextest, cargo-tarpaulin.</li>
+<li>Rust (async/await, Tokio, Actix, Axum) with Anchor and Solana SDK on the runtime side.</li>
+<li>PostgreSQL, FoundationDB, RocksDB, and IPFS for storage, backed by Terraform-managed Kubernetes and GitOps.</li>
+<li>Prometheus, Grafana, OpenTelemetry, and k6 for tracing, observability, and performance testing.</li>
 </ul>
 <h3>Senior Rust Developer @ Kaspersky Lab | May 2021 – March 2022</h3>
 <ul>
@@ -102,62 +92,39 @@
 </ul>
 <p><strong>Tech Stack &amp; Tooling</strong></p>
 <ul>
-<li>Backend &amp; services: Rust (Actix Web, Axum, Hyper, tonic), C++, Python, gRPC, GraphQL, REST, WebSockets, Protocol Buffers, FlatBuffers, Apache Thrift.</li>
-<li>Security &amp; cryptography: PKCS#11, HSM, TLS 1.3, mTLS, OAuth 2.0, OpenID Connect, JWT, hardware-backed key storage, FIPS 140-2 compliance, YubiKey.</li>
-<li>Data &amp; infrastructure: PostgreSQL, Oracle, MS SQL Server, Redis, Apache Cassandra, Apache Kafka, RabbitMQ, HashiCorp Vault, Consul, Nomad, Docker, Kubernetes, OpenShift, VMware Tanzu, Ceph.</li>
-<li>Testing &amp; reliability: GitLab CI/CD, TeamCity, Jenkins, Azure DevOps, Bazel, Conan, Artifactory, SonarQube, Fortify, Checkmarx, Veracode, Git Secrets, OWASP ZAP, Burp Suite, Prometheus, Grafana, ELK.</li>
+<li>Rust (Actix Web, Axum, Hyper, tonic) alongside C++ and Python services exposed through gRPC and GraphQL.</li>
+<li>Vault-backed PostgreSQL and Kafka deployments running on Kubernetes and OpenShift.</li>
+<li>GitLab CI/CD, Jenkins, SonarQube, and Fortify reinforcing secure delivery.</li>
 </ul>
-<h2>Operating Rhythm &amp; Governance</h2>
-<ul>
-<li>Weekly portfolio reviews with business stakeholders, surfacing KPI movements and budget status.</li>
-<li>Quarterly planning rituals that align product, engineering, and operations on priorities and capacity.</li>
-<li>Continuous improvement loops—retrospectives, survey feedback, and actionable experiments.</li>
-<li>Data-informed reporting through Jira dashboards, Confluence scorecards, and lightweight memos.</li>
-</ul>
-<h2>Results &amp; Impact</h2>
+<h2>Results &amp; Operating Rhythm</h2>
 <ul>
 <li>Delivery stayed within 5% of budget during a 6-month team expansion.</li>
 <li>Bug backlog shrank by ~30% after reinforcing QA, code reviews, and release gates.</li>
-<li>Maintained ~90% adherence to quarterly KPIs despite scope churn and infrastructure constraints.</li>
+<li>Maintain weekly stakeholder reviews, quarterly planning, and continuous improvement loops that surface risks early.</li>
+<li>Reporting relies on concise Jira dashboards, Confluence scorecards, and memos that map decisions to measurable impact.</li>
 </ul>
-<h2>Tools &amp; Practices</h2>
+<h2>Tooling Snapshot</h2>
 <ul>
-<li>Planning: Jira Advanced Roadmaps, Notion roadmaps, Confluence specs, Linear, Shortcut, Productboard, Aha!, ClickUp, Miro, FigJam.</li>
-<li>Delivery: Scrum, Kanban hybrids, SAFe, LeSS, Shape Up, async updates, definition-of-done enforcement, dual-track discovery, OKR cadences.</li>
-<li>Quality: GitLab CI/CD, GitHub Actions, CircleCI, Buildkite, Argo Rollouts, feature flags, blue/green deployments, chaos engineering, risk registers, static analysis gates.</li>
-<li>People: Competency matrices, growth plans, structured 1:1s, skip-level feedback, calibration sessions, succession planning, mentoring guilds.</li>
-<li>Architecture &amp; DevOps: Domain-driven design, event sourcing, CQRS, hexagonal architecture, microservices, serverless, container orchestration, service mesh, edge computing, zero-trust networking.</li>
-</ul>
-<h2>Technical Keywords</h2>
-<ul>
-<li>Rust, Go, Python, TypeScript, JavaScript, C++, Solidity, WebAssembly, Solana, Anchor, Substrate, Cosmos SDK, GraphQL, gRPC, REST, SOAP, WebSockets, MQTT, OPC UA.</li>
-<li>PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, ClickHouse, Snowflake, BigQuery, Redshift, MongoDB, Couchbase, Cassandra, ScyllaDB, Neo4j, JanusGraph, Dgraph, Elasticsearch.</li>
-<li>Kafka, RabbitMQ, ActiveMQ, IBM MQ, NATS, Pulsar, AWS Kinesis, Google Pub/Sub, Azure Event Hubs, Debezium, Change Data Capture, Apache Flink, Spark Streaming.</li>
-<li>Docker, Podman, containerd, Kubernetes, OpenShift, Nomad, HashiCorp Vault, Consul, Istio, Linkerd, Envoy, Cilium, Calico, MetalLB, Knative, OpenFaaS.</li>
-<li>Terraform, Pulumi, Crossplane, AWS CloudFormation, Azure Bicep, Google Deployment Manager, Ansible, Chef, Puppet, SaltStack, Packer, Vagrant.</li>
-<li>AWS (EKS, ECS, Lambda, EC2, S3, DynamoDB, RDS, Aurora, API Gateway), GCP (GKE, Cloud Run, Cloud Functions, Spanner, Bigtable), Azure (AKS, Functions, Cosmos DB, Event Grid), DigitalOcean, Hetzner Cloud.</li>
-<li>GitLab CI, GitHub Actions, Jenkins, TeamCity, Azure DevOps, CircleCI, Buildkite, Travis CI, Codefresh, Argo CD, FluxCD, Spinnaker, Harness, Atlantis.</li>
-<li>Prometheus, Grafana, Loki, Tempo, Cortex, Thanos, OpenTelemetry, Jaeger, Zipkin, Kibana, Elastic Stack, Datadog, New Relic, Splunk, Sentry, Honeycomb, PagerDuty, Opsgenie, VictorOps.</li>
-<li>Security &amp; compliance: SonarQube, Snyk, Trivy, Clair, Aqua, Prisma Cloud, HashiCorp Boundary, Vault, Open Policy Agent, Kyverno, Falco, Istio mTLS, SPIFFE/SPIRE, Vault Secrets Engines, CIS Benchmarks, ISO 27001.</li>
-<li>Collaboration: Jira, Confluence, Notion, Google Workspace, Microsoft 365, Slack, Mattermost, Zoom, Loom, Git, GitHub, GitLab, Bitbucket, Phabricator.</li>
+<li>Daily languages: Rust, Go, Python, and TypeScript with PostgreSQL, ClickHouse, and Redis at the core.</li>
+<li>Platform: Kubernetes, Terraform, and Argo CD across AWS, GCP, and Azure with GitOps workflows.</li>
+<li>Quality gates: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus, and Grafana for delivery, security, and observability.</li>
+<li>Collaboration stack: Jira, Confluence, Notion, Slack, GitHub, and GitLab.</li>
 </ul>
 <h2>What I Offer</h2>
 <ul>
-<li>Executive-ready communication paired with credible technical depth.</li>
-<li>Ability to bootstrap or mature engineering processes without slowing delivery.</li>
-<li>Proven record of scaling teams, mentoring leaders, and maintaining morale through change.</li>
+<li>Straightforward communication backed by hands-on technical depth.</li>
+<li>Launch or tune engineering processes without slowing the team.</li>
+<li>Scale teams, mentor new leads, and keep morale steady through change.</li>
 </ul>
 <h2>Additional Information</h2>
 <ul>
 <li><a href="https://qqrm.github.io/CV/">Full CV</a></li>
-<li>Full CV PDFs: <a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="light" data-dark-label="dark">light</a> · </li>
+<li>Download PDF: <a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="light theme" data-dark-label="dark theme">light theme</a> · </li>
 </ul>
 
 </div>
 <footer>
-<p><em><a href="ru/">Link to Russian version</a></em> \
-
-</p>
+<p><em><a href="ru/">Link to Russian version</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -29,8 +29,8 @@
 <div class='content'>
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>
 
-<p><em><a href="../">Ссылка на английскую версию</a></em> \
-
+<p><em><a href="../">Ссылка на английскую версию</a></em></p>
+<p>
 </p>
 <ul>
 <li><strong>Телефон:</strong> +7 (911) 261-70-72</li>
@@ -39,125 +39,92 @@
 <li><strong>Формат работы:</strong> Удалённо, полный день</li>
 </ul>
 <h2>Профиль руководителя разработки</h2>
-<p>Практикующий инженерный лидер и приверженец DevOps, который масштабирует кросс-функциональные команды, ведёт сложные программы миграции и обеспечивает прозрачность метрик для руководства. Умеет выстраивать архитектурное единство, развивать людей, управлять релизами и держать бюджет под контролем без просадки по скорости поставки.</p>
+<p>Руководитель разработки, который проводит миграции платформ без срывов по срокам и бюджету. Держу стейкхолдеров в курсе через понятные метрики, предсказуемые релизы и прямую коммуникацию на языке продукта и инженеров.</p>
 <h2>Ключевые сильные стороны</h2>
 <ul>
-<li>Ведение дорожных карт для нескольких команд и направлений.</li>
-<li>Проработка KPI/OKR, прозрачный трекинг и отчётность для стейкхолдеров.</li>
-<li>Планирование бюджета, набор и взаимодействие с подрядчиками в гибридной инфраструктуре.</li>
-<li>Развитие специалистов через менторство, найм и регулярные performance review.</li>
-<li>Системы управления доставкой, которые балансируют скорость и контроль рисков.</li>
-<li>DevOps-стратегия, релизное управление и взаимодействие с SRE.</li>
+<li>Веду дорожные карты из нескольких команд, сохраняя темп миграций.</li>
+<li>Даю руководству честные апдейты на основе метрик и рабочих дашбордов.</li>
+<li>Набираю, развиваю и удерживаю инженеров, пока они не готовы вести команды.</li>
+<li>Выстраиваю релизные и инцидентные процессы, которые защищают скорость и людей.</li>
 </ul>
 <h2>Опыт работы</h2>
 <h3>Руководитель разработки @ Inline Group | март 2023 – настоящее время (DURATION)</h3>
 <p><em>март 2023 – настоящее время</em></p>
 <p><strong>Лидерство и поставка</strong></p>
 <ul>
-<li>Руководил программой из 25 человек по замене SAP на микросервисы на Rust.</li>
-<li>Согласовывал работу лидов бэкенда, QA, аналитики и DevOps, удерживая единый график релизов.</li>
-<li>Балансировал дорожную карту, бюджет миграции и квартальные цели, заранее подсвечивая риски.</li>
-<li>Внедрил асинхронное и персональное планирование спринтов, что повысило продуктивность примерно на 15% и предсказуемость примерно на 25%.</li>
-<li>Возглавил релизный комитет, синхронизировав QA-аппрувы, SAST-политику и готовность инфраструктуры для предсказуемых релизов.</li>
+<li>Руководил программой из 25 человек по замене SAP на Rust-микросервисы без потери квартальных целей.</li>
+<li>Координировал лидов бэкенда, QA, аналитики и DevOps, чтобы решения по дорожной карте и бюджету были прозрачными.</li>
+<li>Внедрил асинхронное и персональное планирование спринтов, подняв продуктивность примерно на 15% и предсказуемость примерно на 25%.</li>
+<li>Вёл компактный релизный совет, выравнивая QA-аппрувы, SAST-политику и готовность инфраструктуры.</li>
 </ul>
 <p><strong>Технологии и инструменты</strong></p>
 <ul>
-<li>Языки и фреймворки: Rust (Tokio, Actix Web, Axum, tonic), Go, Python, TypeScript, React, Node.js, GraphQL, gRPC, REST, OpenAPI, AsyncAPI.</li>
-<li>Данные и интеграции: PostgreSQL, MySQL, ClickHouse, MongoDB, Redis, Tarantool, Apache Kafka, RabbitMQ, NATS, Apache Pulsar, Debezium, ElasticSearch, OpenSearch, MinIO/S3.</li>
-<li>Облако и инфраструктура: Kubernetes, Docker, containerd, AWS (EKS, ECS, Lambda, CloudWatch), GCP (GKE, Cloud Run, Pub/Sub), Azure (AKS, Functions), HashiCorp Vault, Consul, Nomad, Istio, Linkerd, Envoy, Service Mesh Interface.</li>
-<li>IaC и автоматизация: Terraform, Pulumi, Helm, Kustomize, Argo CD, FluxCD, Ansible, Packer, Argo Workflows, GitOps-пайплайны, Crossplane, Renovate, Dependabot.</li>
-<li>CI/CD и безопасность: GitLab CI, GitHub Actions, Jenkins, TeamCity, Buildkite, SonarQube, Snyk, Trivy, Clair, Harbor, HashiCorp Boundary, Open Policy Agent, Kyverno, Falco, Vault Secrets Engines.</li>
-<li>Наблюдаемость и SRE: Prometheus, Grafana, Loki, Tempo, Alertmanager, OpenTelemetry, Jaeger, Zipkin, Kibana, Datadog, New Relic, Splunk, ELK, Sentry, PagerDuty, Opsgenie, Chaos Mesh.</li>
+<li>Rust (Tokio, Actix Web, Axum, tonic) и поддерживающие сервисы на Go, Python и TypeScript.</li>
+<li>PostgreSQL, ClickHouse, Redis, Kafka и NATS для хранения и обмена данными.</li>
+<li>Kubernetes на AWS, GCP и Azure с автоматизацией через Terraform, Argo CD и GitOps.</li>
+<li>GitLab CI, GitHub Actions, SonarQube, Snyk и Prometheus/Grafana как основа качества и надёжности.</li>
 </ul>
 <p><strong>Люди и управление</strong></p>
 <ul>
-<li>Увеличил бэкенд-команду с 5 до 12 разработчиков, сократив онбординг примерно на 30%.</li>
-<li>Сохранил 90% новых сотрудников после первого года за счёт планов развития и регулярной обратной связи.</li>
-<li>Вырастил трёх инженеров до уровня senior по матрице компетенций и адресному коучингу.</li>
-<li>Включил статический анализ (Clippy, cargo-audit, SonarQube) и внутренний пакетный репозиторий для соответствия требованиям ИБ.</li>
-<li>Популяризировал DevOps-подходы: совмещал разбор инцидентов с автоматизацией задач и масштабровал CI/CD практики на команды.</li>
+<li>Вырастил бэкенд с 5 до 12 инженеров, сократив онбординг примерно на 30%.</li>
+<li>Удержал 90% наймов после первого года благодаря планам развития и регулярной обратной связи.</li>
+<li>Менторил трёх инженеров до senior-уровня и внедрил статанализ и внутреннюю доставку пакетов под требования ИБ.</li>
 </ul>
 <h3>Rust Team Lead @ Solcery | март 2022 – март 2023</h3>
 <ul>
-<li>Управлял командой из 4 Rust-разработчиков, создающих блокчейн-базу данных для DAO на Solana.</li>
-<li>Переводил продуктовые цели в план спринтов, объём релизов и технические спецификации.</li>
-<li>Сократил среднее время код-ревью примерно на 40% за счёт правил, парного программирования и автотестов.</li>
-<li>Внедрил версионирование схем и миграции, что снизило издержки поддержки и ускорило адаптацию новичков.</li>
-<li>Добавил распределённый трейсинг, канареечные релизы и панели здоровья смарт-контрактов.</li>
+<li>Управлял командой из 4 Rust-разработчиков, создающих блокчейн-базу данных под Solana.</li>
+<li>Переводил продуктовые цели в планы спринтов, объём релизов и понятные спецификации.</li>
+<li>Сократил код-ревью примерно на 40% за счёт правил, парного программирования и автотестов.</li>
+<li>Добавил версионирование схем, миграции, распределённый трейсинг и канареечные релизы.</li>
 </ul>
 <p><strong>Технологии и инструменты</strong></p>
 <ul>
-<li>Протоколы и рантаймы: Rust (async/await, Tokio, Actix, Axum), Anchor, Solana SDK, WebAssembly, Web3.js, TypeScript, React, Next.js, Node.js, GraphQL, gRPC, REST.</li>
-<li>Данные и хранение: PostgreSQL, FoundationDB, RocksDB, IPFS, Redis, ClickHouse, TimescaleDB, Apache Arrow, Delta Lake, Parquet, Apache Spark для аналитических бэкфилов.</li>
-<li>Блокчейн и криптография: Solana Programs, Metaplex, SPL tokens, BPF toolchain, zero-knowledge circuits (Halo2, zk-SNARKs), Ledger hardware wallets, HSM, защищённые анклавы (Intel SGX).</li>
-<li>DevOps и автоматизация: Docker, Kubernetes, k3s, Terraform, Helm, GitHub Actions, GitLab CI, CircleCI, Argo CD, Argo Rollouts, GitOps, HashiCorp Vault, Ansible, Consul Template, Nomad, HashiCorp Packer.</li>
-<li>Наблюдаемость и QA: Prometheus, Grafana, Loki, Tempo, OpenTelemetry, Jaeger, Kibana, ElasticSearch, Datadog, Chaos Monkey, k6, Gatling, pytest, cargo-nextest, cargo-tarpaulin.</li>
+<li>Rust (async/await, Tokio, Actix, Axum) с Anchor и Solana SDK.</li>
+<li>PostgreSQL, FoundationDB, RocksDB и IPFS, развёрнутые на Kubernetes под управлением Terraform и GitOps.</li>
+<li>Prometheus, Grafana, OpenTelemetry и k6 для трассировки, наблюдаемости и нагрузочного тестирования.</li>
 </ul>
 <h3>Senior Rust Developer @ Kaspersky Lab | май 2021 – март 2022</h3>
 <ul>
 <li>Работал на стыке продукта, QA и операций, поддерживая блокчейн-платформу голосования.</li>
-<li>Увеличил покрытие тестами примерно до 75%, снизив количество пострелизных инцидентов примерно на 25%.</li>
-<li>Вёл рефакторинг, упрощающий ввод новых фич и передачу знаний между командами.</li>
+<li>Увеличил покрытие тестами примерно до 75%, снизив пострелизные инциденты примерно на 25%.</li>
+<li>Вёл рефакторинг, упрощающий ввод новых фич и обмен знаниями между командами.</li>
 <li>Усилил криптомодули и контейнеризацию для безопасного хранения бюллетеней и аудита.</li>
 </ul>
 <p><strong>Технологии и инструменты</strong></p>
 <ul>
-<li>Бэкенд и сервисы: Rust (Actix Web, Axum, Hyper, tonic), C++, Python, gRPC, GraphQL, REST, WebSockets, Protocol Buffers, FlatBuffers, Apache Thrift.</li>
-<li>Безопасность и криптография: PKCS#11, HSM, TLS 1.3, mTLS, OAuth 2.0, OpenID Connect, JWT, аппаратное хранение ключей, FIPS 140-2, YubiKey.</li>
-<li>Данные и инфраструктура: PostgreSQL, Oracle, MS SQL Server, Redis, Apache Cassandra, Apache Kafka, RabbitMQ, HashiCorp Vault, Consul, Nomad, Docker, Kubernetes, OpenShift, VMware Tanzu, Ceph.</li>
-<li>Тестирование и надёжность: GitLab CI/CD, TeamCity, Jenkins, Azure DevOps, Bazel, Conan, Artifactory, SonarQube, Fortify, Checkmarx, Veracode, Git Secrets, OWASP ZAP, Burp Suite, Prometheus, Grafana, ELK.</li>
+<li>Rust (Actix Web, Axum, Hyper, tonic) вместе с сервисами на C++ и Python через gRPC и GraphQL.</li>
+<li>PostgreSQL и Kafka с секретами в Vault, развёрнутые на Kubernetes и OpenShift.</li>
+<li>GitLab CI/CD, Jenkins, SonarQube и Fortify для безопасной доставки.</li>
 </ul>
-<h2>Операционный ритм и управление</h2>
+<h2>Результаты и ритм работы</h2>
 <ul>
-<li>Еженедельные портфельные ревью с бизнесом: статус KPI, бюджет, риски.</li>
-<li>Квартальное планирование с выравниванием продуктовой, инженерной и операционной повестки.</li>
-<li>Постоянное улучшение — ретроспективы, опросы и эксперименты с измеримым эффектом.</li>
-<li>Отчётность на данных через дашборды Jira, конспекты в Confluence и лаконичные мемо.</li>
+<li>Держал доставку в пределах 5% от бюджета во время шестимесячного роста команды.</li>
+<li>Сократил баг-бэклог примерно на 30% за счёт усиленного QA и контроля релизов.</li>
+<li>Поддерживаю еженедельные встречи со стейкхолдерами, квартальное планирование и постоянные улучшения, чтобы риски всплывали заранее.</li>
+<li>Отчётность строю на дашбордах Jira, сводках в Confluence и коротких мемо с измеримыми решениями.</li>
 </ul>
-<h2>Результаты</h2>
+<h2>Технологический профиль</h2>
 <ul>
-<li>Доставка оставалась в пределах 5% от бюджета во время шестимесячного роста команды.</li>
-<li>Баг-бэклог сократился примерно на 30% благодаря усиленным QA-практикам и контролю релизов.</li>
-<li>Удерживал примерно 90% выполнения квартальных KPI даже при изменении объёма и ограничениях инфраструктуры.</li>
-</ul>
-<h2>Инструменты и практики</h2>
-<ul>
-<li>Планирование: Jira Advanced Roadmaps, дорожные карты в Notion, спецификации в Confluence, Linear, Shortcut, Productboard, Aha!, ClickUp, Miro, FigJam.</li>
-<li>Доставка: Scrum, гибриды Kanban, SAFe, LeSS, Shape Up, асинхронные апдейты, жёсткий Definition of Done, dual-track discovery, OKR-циклы.</li>
-<li>Качество: GitLab CI/CD, GitHub Actions, CircleCI, Buildkite, Argo Rollouts, feature flags, blue/green, chaos engineering, матрицы рисков, статический анализ.</li>
-<li>Люди: матрицы компетенций, планы развития, структурированные 1:1, skip-level обратная связь, калибровочные сессии, succession planning, менторские гильдии.</li>
-<li>Архитектура и DevOps: Domain-driven design, event sourcing, CQRS, hexagonal architecture, микросервисы, serverless, оркестрация контейнеров, сервис-меш, edge computing, zero-trust.</li>
-</ul>
-<h2>Ключевые технологии</h2>
-<ul>
-<li>Rust, Go, Python, TypeScript, JavaScript, C++, Solidity, WebAssembly, Solana, Anchor, Substrate, Cosmos SDK, GraphQL, gRPC, REST, SOAP, WebSockets, MQTT, OPC UA.</li>
-<li>PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, ClickHouse, Snowflake, BigQuery, Redshift, MongoDB, Couchbase, Cassandra, ScyllaDB, Neo4j, JanusGraph, Dgraph, Elasticsearch.</li>
-<li>Kafka, RabbitMQ, ActiveMQ, IBM MQ, NATS, Pulsar, AWS Kinesis, Google Pub/Sub, Azure Event Hubs, Debezium, Change Data Capture, Apache Flink, Spark Streaming.</li>
-<li>Docker, Podman, containerd, Kubernetes, OpenShift, Nomad, HashiCorp Vault, Consul, Istio, Linkerd, Envoy, Cilium, Calico, MetalLB, Knative, OpenFaaS.</li>
-<li>Terraform, Pulumi, Crossplane, AWS CloudFormation, Azure Bicep, Google Deployment Manager, Ansible, Chef, Puppet, SaltStack, Packer, Vagrant.</li>
-<li>AWS (EKS, ECS, Lambda, EC2, S3, DynamoDB, RDS, Aurora, API Gateway), GCP (GKE, Cloud Run, Cloud Functions, Spanner, Bigtable), Azure (AKS, Functions, Cosmos DB, Event Grid), DigitalOcean, Hetzner Cloud.</li>
-<li>GitLab CI, GitHub Actions, Jenkins, TeamCity, Azure DevOps, CircleCI, Buildkite, Travis CI, Codefresh, Argo CD, FluxCD, Spinnaker, Harness, Atlantis.</li>
-<li>Prometheus, Grafana, Loki, Tempo, Cortex, Thanos, OpenTelemetry, Jaeger, Zipkin, Kibana, Elastic Stack, Datadog, New Relic, Splunk, Sentry, Honeycomb, PagerDuty, Opsgenie, VictorOps.</li>
-<li>Безопасность и соответствие: SonarQube, Snyk, Trivy, Clair, Aqua, Prisma Cloud, HashiCorp Boundary, Vault, Open Policy Agent, Kyverno, Falco, Istio mTLS, SPIFFE/SPIRE, Vault Secrets Engines, CIS Benchmarks, ISO 27001.</li>
-<li>Коллаборация: Jira, Confluence, Notion, Google Workspace, Microsoft 365, Slack, Mattermost, Zoom, Loom, Git, GitHub, GitLab, Bitbucket, Phabricator.</li>
+<li>Ежедневные языки: Rust, Go, Python и TypeScript с базами PostgreSQL, ClickHouse и Redis.</li>
+<li>Платформа: Kubernetes, Terraform и Argo CD на AWS, GCP и Azure с GitOps-процессами.</li>
+<li>Контроль качества: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus и Grafana.</li>
+<li>Совместная работа: Jira, Confluence, Notion, Slack, GitHub и GitLab.</li>
 </ul>
 <h2>Что предлагаю</h2>
 <ul>
-<li>Понятная коммуникация для руководства и глубокое понимание технических деталей.</li>
-<li>Умение запускать или усиливать инженерные процессы без просадки по скорости.</li>
-<li>Доказанный опыт масштабирования команд, развития лидов и поддержания мотивации при изменениях.</li>
+<li>Простая коммуникация для руководства и глубокое техническое погружение.</li>
+<li>Умею запускать или усиливать процессы без просадки по скорости команды.</li>
+<li>Масштабирую команды, развиваю лидов и держу мотивацию в периоды изменений.</li>
 </ul>
 <h2>Дополнительно</h2>
 <ul>
 <li><a href="https://qqrm.github.io/CV/">Полное CV</a></li>
-<li>Полные PDF-версии CV: <a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="светлая" data-dark-label="тёмная">светлая</a> · </li>
+<li>Скачать PDF: <a href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="светлая тема" data-dark-label="тёмная тема">светлая тема</a> · </li>
 </ul>
 
 </div>
 <footer>
-<p><em><a href="../">Ссылка на английскую версию</a></em> \
-
-</p>
+<p><em><a href="../">Ссылка на английскую версию</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>


### PR DESCRIPTION
## Summary
- rewrite the English CV copy to remove buzzwords, add direct bullet points, and surface cleaner PDF links
- mirror the streamlined narrative in the Russian CV variant while keeping download links visible
- regenerate the normalized HTML fixtures for the site generator so tests track the new content structure
- Avatar: tech_lead (Rust Tech Lead) — chosen to balance content edits with engineering context for the resume site

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- cargo machete
- wrkflw validate
- wrkflw run .github/workflows/build-test.yml *(failed: Docker unavailable, emulation hung; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68e5943f4a6c83328b92cd76e1d6a7e0