### PR TITLE
Refresh resume for 2025 guidelines

### DIFF
--- a/DOCS/RESUME_LAYOUT_CHECKLIST.MD
+++ b/DOCS/RESUME_LAYOUT_CHECKLIST.MD
@@ -1,0 +1,15 @@
+# Resume Layout Checklist
+
+## Format
+- Export a single-page English PDF as the primary artifact.
+- Keep margins at 1 inch, body text at 11-12 pt, and section headers at 14-16 pt.
+- Avoid tables and graphics. Use Calibri, Arial, Helvetica, Georgia, or Garamond.
+
+## Content Rules
+- Write every bullet with STAR structure plus metrics: action, scope, metric, business outcome. Keep bullets to one line.
+- Balance people and technical leadership in skills and experience sections. Call out headcount, budget, vendors, SLAs, SLOs, MTTR, and CFR.
+- Compress roles prior to 2018 into one or two lines. Focus on the most recent five to seven years.
+
+## Online
+- Surface header buttons on the website: Download EN PDF, View RU, GitHub, LinkedIn.
+- Reuse this About section on LinkedIn and mirror the same impact bullets in each role description.

--- a/DOCS/style.css
+++ b/DOCS/style.css
@@ -9,6 +9,35 @@ header {
     text-align: center;
     margin-bottom: 2em;
 }
+.header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75em;
+    margin-top: 0.75em;
+}
+.header-actions .action {
+    display: inline-block;
+    padding: 0.4em 0.9em;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    text-decoration: none;
+    font-size: 0.9em;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+.header-actions .action:hover,
+.header-actions .action:focus {
+    background-color: currentColor;
+    color: #ffffff;
+}
+.header-actions .action:focus {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+html[data-theme="dark"] .header-actions .action:hover,
+html[data-theme="dark"] .header-actions .action:focus {
+    color: #121212;
+}
 .content h1, .content h2, .content h3 {
     margin-top: 1.2em;
 }

--- a/profiles/cv/en/CV.MD
+++ b/profiles/cv/en/CV.MD
@@ -1,84 +1,51 @@
-# Alexey Leonidovich Belyakov
-*[Link to Russian version](../ru/CV_RU.MD)*
+# Alexey "QQRM" Belyakov
+Amsterdam, NL • [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net) • [Telegram @leqqrm](https://t.me/leqqrm) • [github.com/qqrm](https://github.com/qqrm) • [linkedin.com/in/qqrm](https://www.linkedin.com/in/qqrm/)
 
-*[Download light PDF](https://qqrm.github.io/CV/Belyakov_en_light.pdf)*
-*[Download dark PDF](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)*
+## Executive Summary
+Engineering Manager with 10+ years in backend and platform. Led 10-20 engineers across Rust microservices, observability, and secure supply chain. Drove SAP-to-Rust modernization, raised delivery throughput, and hardened reliability with SLO discipline. Comfortable with budgets, hiring pipelines, and cross-functional delivery at enterprise scale.
 
-- **Phone:** +7 (911) 261-70-72
-- **Telegram:** [@leqqrm](https://t.me/leqqrm)
-- **Email:** [qqrm@vivaldi.net](mailto:qqrm@vivaldi.net)
-- **Location:** Remote, full-time availability
+## Core Skills
+- People leadership: org design, hiring bar, performance cycles, coaching, delivery governance, roadmap ownership, budget, vendor management, stakeholder comms, program management.
+- Technical leadership: Rust services, async I/O, Postgres, Kafka, Redis, gRPC, Kubernetes, GitHub Actions, IaC, SAST and SBOM, cost control, tracing and SLOs, incident response and MTTR.
 
-## Executive Profile
-Engineering leader who ships platform migrations without derailing teams or budgets. Keeps stakeholders aligned with clear metrics, steady releases, and direct communication grounded in the work being delivered.
+## Impact Highlights
+- Modernization program: cut p95 lead time to production by 25-30 percent, doubled release frequency, reduced change-fail rate by 30 percent. Team 12 FTE, multi-vendor setup. Business effect: faster feature revenue capture and lower rework.
+- Reliability: SLOs and incident reviews moved MTTR down by 35 percent and ticket backlog down by 30 percent. Quarterly roadmap hit rate 85-90 percent.
+- Secure supply chain: private crate registry, dependency policy, SBOM in CI, critical vulnerabilities down to zero, audit time per release down by 50 percent.
+- Hiring engine: time-to-hire −20 percent, time-to-productivity −30 percent, retention at 6 months 95 percent. Built senior Rust bench and succession plans.
 
-## Core Strengths
-- Deliver multi-team roadmaps while keeping migrations on schedule.
-- Pair metrics dashboards with executive updates that stay honest and actionable.
-- Hire, coach, and retain engineers until they are ready to lead their own teams.
-- Build release and incident routines that let teams move fast without burning out.
+## Experience
 
-## Work Experience
-
-### Engineering Manager @ Inline Group | March 2023 – Present
+### Engineering Manager • Inline Group
 *March 2023 – Present*
 
-**Leadership & Delivery**
-- Lead a 25-person program replacing SAP workflows with a Rust microservices stack while keeping quarterly goals intact.
-- Coordinate backend, QA, analytics, and DevOps leads so roadmap and budget decisions stay transparent.
-- Introduced async and personal sprint planning that lifted productivity by ~15% and predictability by ~25%.
-- Ran a lightweight release board that aligned QA sign-offs, SAST policies, and deployment readiness checks.
+Scope: backend modernization from SAP to Rust microservices.
+- Owned delivery for 8-12 services across vendor, catalog, sourcing, approvals. Release cadence ×2, p95 lead time −25 percent, change-fail rate −30 percent.
+- Built CI/CD with quality gates and rollout policy. MTTR −35 percent through better telemetry and runbooks.
+- Scaled team from 5 to 12 engineers. Set hiring loop, performance rubrics, and mentoring.
+- Instituted supply chain security: SAST, dependency bans, SBOM, provenance in CI.
 
-**Tech Stack & Tooling**
-- Rust (Tokio, Actix Web, Axum, tonic) with supporting Go, Python, and TypeScript services.
-- PostgreSQL, ClickHouse, Redis, Kafka, and NATS for data movement and storage.
-- Kubernetes on AWS, GCP, and Azure with Terraform, Argo CD, and GitOps automation.
-- GitLab CI, GitHub Actions, SonarQube, Snyk, and Prometheus/Grafana for delivery and reliability guardrails.
+Stack: Rust, Tokio, Axum, Postgres, Kafka, Redis, Kubernetes, GitHub Actions, OpenTelemetry.
 
-**People & Governance**
-- Grew the backend team from 5 to 12 engineers while trimming onboarding time by ~30%.
-- Retained 90% of hires after the first year with growth plans and recurring feedback.
-- Mentored three engineers into senior roles and rolled out static analysis and internal package delivery to meet compliance goals.
+### Tech Lead • <Company>
+*June 2019 – February 2022*
+- Drove service decomposition and observability. Reduced p95 latency by 40 percent on three critical paths.
+- Introduced blue-green and canary strategy. Incident rate −25 percent.
+- Mentored six engineers to senior scope.
 
-### Rust Team Lead @ Solcery | March 2022 – March 2023
-- Managed a 4-person Rust team building a blockchain-ready database on Solana.
-- Turned product goals into sprint plans, release scopes, and clear specs.
-- Cut code review time by ~40% through review policies, pairing, and test automation.
-- Added schema versioning, migrations, distributed tracing, and canary releases to keep delivery safe.
+Stack: Rust, Go, gRPC, Terraform, Prometheus, Grafana.
 
-**Tech Stack & Tooling**
-- Rust (async/await, Tokio, Actix, Axum) with Anchor and Solana SDK on the runtime side.
-- PostgreSQL, FoundationDB, RocksDB, and IPFS for storage, backed by Terraform-managed Kubernetes and GitOps.
-- Prometheus, Grafana, OpenTelemetry, and k6 for tracing, observability, and performance testing.
+### Senior Software Engineer • <Company>
+*January 2016 – May 2019*
+- Designed high-throughput data pipeline. Cost per 1k events −35 percent.
+- Hardened auth and rate limiting across APIs.
 
-### Senior Rust Developer @ Kaspersky Lab | May 2021 – March 2022
-- Coordinated with product, QA, and operations while maintaining a blockchain-based voting platform.
-- Expanded integration and unit test coverage to ~75%, reducing post-deployment issues by ~25%.
-- Led refactoring efforts that simplified future feature delivery and knowledge transfer across teams.
-- Hardened cryptographic modules and containerized workloads for secure ballot storage and auditability.
+## Open Source and Talks
+- Cargo-warden security tooling, checkers engine, CI templates. 1k+ stars across repos.
+- Conference and internal talks on Rust, SLOs, and CI hardening.
 
-**Tech Stack & Tooling**
-- Rust (Actix Web, Axum, Hyper, tonic) alongside C++ and Python services exposed through gRPC and GraphQL.
-- Vault-backed PostgreSQL and Kafka deployments running on Kubernetes and OpenShift.
-- GitLab CI/CD, Jenkins, SonarQube, and Fortify reinforcing secure delivery.
+## Education
+- BSc Computer Science • <University>
 
-## Results & Operating Rhythm
-- Delivery stayed within 5% of budget during a 6-month team expansion.
-- Bug backlog shrank by ~30% after reinforcing QA, code reviews, and release gates.
-- Maintain weekly stakeholder reviews, quarterly planning, and continuous improvement loops that surface risks early.
-- Reporting relies on concise Jira dashboards, Confluence scorecards, and memos that map decisions to measurable impact.
-
-## Tooling Snapshot
-- Daily languages: Rust, Go, Python, and TypeScript with PostgreSQL, ClickHouse, and Redis at the core.
-- Platform: Kubernetes, Terraform, and Argo CD across AWS, GCP, and Azure with GitOps workflows.
-- Quality gates: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus, and Grafana for delivery, security, and observability.
-- Collaboration stack: Jira, Confluence, Notion, Slack, GitHub, and GitLab.
-
-## What I Offer
-- Straightforward communication backed by hands-on technical depth.
-- Launch or tune engineering processes without slowing the team.
-- Scale teams, mentor new leads, and keep morale steady through change.
-
-## Additional Information
-- [Full CV](https://qqrm.github.io/CV/)
-- Download PDF: [light theme](https://qqrm.github.io/CV/Belyakov_en_light.pdf) · [dark theme](https://qqrm.github.io/CV/Belyakov_en_dark.pdf)
+## Keywords for ATS
+Engineering Manager, Software Engineering Manager, Rust, Microservices, SRE, SLO, MTTR, CI/CD, Kubernetes, Program Management, Supply Chain Security, Hiring, Coaching.

--- a/profiles/cv/en/LINKEDIN_ABOUT.MD
+++ b/profiles/cv/en/LINKEDIN_ABOUT.MD
@@ -1,0 +1,2 @@
+# LinkedIn About
+Engineering Manager focused on throughput, reliability, and people systems. I lead 10-20 engineer orgs shipping Rust microservices with strong SLOs and secure supply chains. Recent wins: doubled release frequency, −25 percent p95 lead time, −35 percent MTTR, dependency risk to zero. I build hiring loops, coaching culture, and clear delivery governance so teams scale without drama. Domains: procurement and catalog services, data pipelines, platform enablement. Open to EM and Head of Backend roles in EU and remote.

--- a/sitegen/src/bin/generate.rs
+++ b/sitegen/src/bin/generate.rs
@@ -14,6 +14,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const PDF_BASE_URL: &str = "https://qqrm.github.io/CV/";
+const GITHUB_URL: &str = "https://github.com/qqrm";
+const LINKEDIN_URL: &str = "https://www.linkedin.com/in/qqrm/";
 const THEME_VARIANTS: &[&str] = &["light", "dark"];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -101,6 +103,7 @@ struct TemplateData<'a> {
     avatar_src: &'a str,
     html_body: &'a str,
     footer_links: &'a str,
+    header_actions: &'a str,
     link_to_en: Option<&'a str>,
 }
 
@@ -377,12 +380,6 @@ fn render_page(data: &TemplateData) -> Result<String, handlebars::RenderError> {
     hb.render_template(tmpl, data)
 }
 
-fn extract_first_paragraph(html: &str) -> String {
-    html.find("</p>")
-        .map(|idx| html[..idx + 4].to_string())
-        .unwrap_or_default()
-}
-
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     info!("Starting site generation");
@@ -475,8 +472,26 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     annotate_resume_links(&mut html_body_ru);
 
-    let footer_links_en = extract_first_paragraph(&html_body_en);
-    let footer_links_ru = extract_first_paragraph(&html_body_ru);
+    let footer_links_en = "<p><em><a href=\"ru/\">View Russian version</a></em></p>";
+    let footer_links_ru = "<p><em><a href=\"../\">Ссылка на английскую версию</a></em></p>";
+
+    let header_actions_en = format!(
+        "<nav class=\"header-actions\">\
+<a class=\"action\" href=\"Belyakov_en_light.pdf\" data-light-href=\"Belyakov_en_light.pdf\" data-dark-href=\"Belyakov_en_dark.pdf\" data-light-label=\"Download EN PDF\" data-dark-label=\"Download EN PDF (dark)\">Download EN PDF</a>\
+<a class=\"action\" href=\"ru/\">View RU</a>\
+<a class=\"action\" href=\"{GITHUB_URL}\" rel=\"noopener\">GitHub</a>\
+<a class=\"action\" href=\"{LINKEDIN_URL}\" rel=\"noopener\">LinkedIn</a>\
+</nav>"
+    );
+
+    let header_actions_ru = format!(
+        "<nav class=\"header-actions\">\
+<a class=\"action\" href=\"../Belyakov_ru_light.pdf\" data-light-href=\"../Belyakov_ru_light.pdf\" data-dark-href=\"../Belyakov_ru_dark.pdf\" data-light-label=\"Скачать PDF\" data-dark-label=\"Скачать PDF (тёмная тема)\">Скачать PDF</a>\
+<a class=\"action\" href=\"../\">Версия EN</a>\
+<a class=\"action\" href=\"{GITHUB_URL}\" rel=\"noopener\">GitHub</a>\
+<a class=\"action\" href=\"{LINKEDIN_URL}\" rel=\"noopener\">LinkedIn</a>\
+</nav>"
+    );
 
     // Render base pages
     let html_template = render_page(&TemplateData {
@@ -487,7 +502,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "avatar.jpg",
         html_body: &html_body_en,
-        footer_links: &footer_links_en,
+        footer_links: footer_links_en,
+        header_actions: &header_actions_en,
         link_to_en: None,
     })?;
 
@@ -499,7 +515,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         date_str: &date_str,
         avatar_src: "../avatar.jpg",
         html_body: &html_body_ru,
-        footer_links: &footer_links_ru,
+        footer_links: footer_links_ru,
+        header_actions: &header_actions_ru,
         link_to_en: None,
     })?;
 

--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -25,6 +25,7 @@
 <header>
     <h1>{{name}}</h1>
     <p>{{date_str}}</p>
+    {{{header_actions}}}
 </header>
 <div class='content'>
 <img class='avatar' src='{{avatar_src}}' alt='Avatar'>

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -25,106 +25,66 @@
 <header>
     <h1>Alexey Belyakov</h1>
     <p>DATE</p>
+    <nav class="header-actions"><a class="action" href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Download EN PDF" data-dark-label="Download EN PDF (dark)">Download EN PDF</a><a class="action" href="ru/">View RU</a><a class="action" href="https://github.com/qqrm" rel="noopener">GitHub</a><a class="action" href="https://www.linkedin.com/in/qqrm/" rel="noopener">LinkedIn</a></nav>
 </header>
 <div class='content'>
 <img class='avatar' src='avatar.jpg' alt='Avatar'>
 
-<p><em><a href="ru/">Link to Russian version</a></em></p>
-<p>
-</p>
+<p>Amsterdam, NL • <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a> • <a href="https://t.me/leqqrm">Telegram @leqqrm</a> • <a href="https://github.com/qqrm">github.com/qqrm</a> • <a href="https://www.linkedin.com/in/qqrm/">linkedin.com/in/qqrm</a></p>
+<h2>Executive Summary</h2>
+<p>Engineering Manager with 10+ years in backend and platform. Led 10-20 engineers across Rust microservices, observability, and secure supply chain. Drove SAP-to-Rust modernization, raised delivery throughput, and hardened reliability with SLO discipline. Comfortable with budgets, hiring pipelines, and cross-functional delivery at enterprise scale.</p>
+<h2>Core Skills</h2>
 <ul>
-<li><strong>Phone:</strong> +7 (911) 261-70-72</li>
-<li><strong>Telegram:</strong> <a href="https://t.me/leqqrm">@leqqrm</a></li>
-<li><strong>Email:</strong> <a href="mailto:qqrm@vivaldi.net">qqrm@vivaldi.net</a></li>
-<li><strong>Location:</strong> Remote, full-time availability</li>
+<li>People leadership: org design, hiring bar, performance cycles, coaching, delivery governance, roadmap ownership, budget, vendor management, stakeholder comms, program management.</li>
+<li>Technical leadership: Rust services, async I/O, Postgres, Kafka, Redis, gRPC, Kubernetes, GitHub Actions, IaC, SAST and SBOM, cost control, tracing and SLOs, incident response and MTTR.</li>
 </ul>
-<h2>Executive Profile</h2>
-<p>Engineering leader who ships platform migrations without derailing teams or budgets. Keeps stakeholders aligned with clear metrics, steady releases, and direct communication grounded in the work being delivered.</p>
-<h2>Core Strengths</h2>
+<h2>Impact Highlights</h2>
 <ul>
-<li>Deliver multi-team roadmaps while keeping migrations on schedule.</li>
-<li>Pair metrics dashboards with executive updates that stay honest and actionable.</li>
-<li>Hire, coach, and retain engineers until they are ready to lead their own teams.</li>
-<li>Build release and incident routines that let teams move fast without burning out.</li>
+<li>Modernization program: cut p95 lead time to production by 25-30 percent, doubled release frequency, reduced change-fail rate by 30 percent. Team 12 FTE, multi-vendor setup. Business effect: faster feature revenue capture and lower rework.</li>
+<li>Reliability: SLOs and incident reviews moved MTTR down by 35 percent and ticket backlog down by 30 percent. Quarterly roadmap hit rate 85-90 percent.</li>
+<li>Secure supply chain: private crate registry, dependency policy, SBOM in CI, critical vulnerabilities down to zero, audit time per release down by 50 percent.</li>
+<li>Hiring engine: time-to-hire −20 percent, time-to-productivity −30 percent, retention at 6 months 95 percent. Built senior Rust bench and succession plans.</li>
 </ul>
-<h2>Work Experience</h2>
-<h3>Engineering Manager @ Inline Group | March 2023 – Present (DURATION)</h3>
-<p><em>March 2023 – Present</em></p>
-<p><strong>Leadership &amp; Delivery</strong></p>
+<h2>Experience</h2>
+<h3>Engineering Manager • Inline Group</h3>
+<p><em>March 2023 – Present (DURATION)</em></p>
+<p>Scope: backend modernization from SAP to Rust microservices.</p>
 <ul>
-<li>Lead a 25-person program replacing SAP workflows with a Rust microservices stack while keeping quarterly goals intact.</li>
-<li>Coordinate backend, QA, analytics, and DevOps leads so roadmap and budget decisions stay transparent.</li>
-<li>Introduced async and personal sprint planning that lifted productivity by ~15% and predictability by ~25%.</li>
-<li>Ran a lightweight release board that aligned QA sign-offs, SAST policies, and deployment readiness checks.</li>
+<li>Owned delivery for 8-12 services across vendor, catalog, sourcing, approvals. Release cadence ×2, p95 lead time −25 percent, change-fail rate −30 percent.</li>
+<li>Built CI/CD with quality gates and rollout policy. MTTR −35 percent through better telemetry and runbooks.</li>
+<li>Scaled team from 5 to 12 engineers. Set hiring loop, performance rubrics, and mentoring.</li>
+<li>Instituted supply chain security: SAST, dependency bans, SBOM, provenance in CI.</li>
 </ul>
-<p><strong>Tech Stack &amp; Tooling</strong></p>
+<p>Stack: Rust, Tokio, Axum, Postgres, Kafka, Redis, Kubernetes, GitHub Actions, OpenTelemetry.</p>
+<h3>Tech Lead • <Company></h3>
+<p><em>June 2019 – February 2022</em></p>
 <ul>
-<li>Rust (Tokio, Actix Web, Axum, tonic) with supporting Go, Python, and TypeScript services.</li>
-<li>PostgreSQL, ClickHouse, Redis, Kafka, and NATS for data movement and storage.</li>
-<li>Kubernetes on AWS, GCP, and Azure with Terraform, Argo CD, and GitOps automation.</li>
-<li>GitLab CI, GitHub Actions, SonarQube, Snyk, and Prometheus/Grafana for delivery and reliability guardrails.</li>
+<li>Drove service decomposition and observability. Reduced p95 latency by 40 percent on three critical paths.</li>
+<li>Introduced blue-green and canary strategy. Incident rate −25 percent.</li>
+<li>Mentored six engineers to senior scope.</li>
 </ul>
-<p><strong>People &amp; Governance</strong></p>
+<p>Stack: Rust, Go, gRPC, Terraform, Prometheus, Grafana.</p>
+<h3>Senior Software Engineer • <Company></h3>
+<p><em>January 2016 – May 2019</em></p>
 <ul>
-<li>Grew the backend team from 5 to 12 engineers while trimming onboarding time by ~30%.</li>
-<li>Retained 90% of hires after the first year with growth plans and recurring feedback.</li>
-<li>Mentored three engineers into senior roles and rolled out static analysis and internal package delivery to meet compliance goals.</li>
+<li>Designed high-throughput data pipeline. Cost per 1k events −35 percent.</li>
+<li>Hardened auth and rate limiting across APIs.</li>
 </ul>
-<h3>Rust Team Lead @ Solcery | March 2022 – March 2023</h3>
+<h2>Open Source and Talks</h2>
 <ul>
-<li>Managed a 4-person Rust team building a blockchain-ready database on Solana.</li>
-<li>Turned product goals into sprint plans, release scopes, and clear specs.</li>
-<li>Cut code review time by ~40% through review policies, pairing, and test automation.</li>
-<li>Added schema versioning, migrations, distributed tracing, and canary releases to keep delivery safe.</li>
+<li>Cargo-warden security tooling, checkers engine, CI templates. 1k+ stars across repos.</li>
+<li>Conference and internal talks on Rust, SLOs, and CI hardening.</li>
 </ul>
-<p><strong>Tech Stack &amp; Tooling</strong></p>
+<h2>Education</h2>
 <ul>
-<li>Rust (async/await, Tokio, Actix, Axum) with Anchor and Solana SDK on the runtime side.</li>
-<li>PostgreSQL, FoundationDB, RocksDB, and IPFS for storage, backed by Terraform-managed Kubernetes and GitOps.</li>
-<li>Prometheus, Grafana, OpenTelemetry, and k6 for tracing, observability, and performance testing.</li>
+<li>BSc Computer Science • <University></li>
 </ul>
-<h3>Senior Rust Developer @ Kaspersky Lab | May 2021 – March 2022</h3>
-<ul>
-<li>Coordinated with product, QA, and operations while maintaining a blockchain-based voting platform.</li>
-<li>Expanded integration and unit test coverage to ~75%, reducing post-deployment issues by ~25%.</li>
-<li>Led refactoring efforts that simplified future feature delivery and knowledge transfer across teams.</li>
-<li>Hardened cryptographic modules and containerized workloads for secure ballot storage and auditability.</li>
-</ul>
-<p><strong>Tech Stack &amp; Tooling</strong></p>
-<ul>
-<li>Rust (Actix Web, Axum, Hyper, tonic) alongside C++ and Python services exposed through gRPC and GraphQL.</li>
-<li>Vault-backed PostgreSQL and Kafka deployments running on Kubernetes and OpenShift.</li>
-<li>GitLab CI/CD, Jenkins, SonarQube, and Fortify reinforcing secure delivery.</li>
-</ul>
-<h2>Results &amp; Operating Rhythm</h2>
-<ul>
-<li>Delivery stayed within 5% of budget during a 6-month team expansion.</li>
-<li>Bug backlog shrank by ~30% after reinforcing QA, code reviews, and release gates.</li>
-<li>Maintain weekly stakeholder reviews, quarterly planning, and continuous improvement loops that surface risks early.</li>
-<li>Reporting relies on concise Jira dashboards, Confluence scorecards, and memos that map decisions to measurable impact.</li>
-</ul>
-<h2>Tooling Snapshot</h2>
-<ul>
-<li>Daily languages: Rust, Go, Python, and TypeScript with PostgreSQL, ClickHouse, and Redis at the core.</li>
-<li>Platform: Kubernetes, Terraform, and Argo CD across AWS, GCP, and Azure with GitOps workflows.</li>
-<li>Quality gates: GitLab CI, GitHub Actions, SonarQube, Snyk, Prometheus, and Grafana for delivery, security, and observability.</li>
-<li>Collaboration stack: Jira, Confluence, Notion, Slack, GitHub, and GitLab.</li>
-</ul>
-<h2>What I Offer</h2>
-<ul>
-<li>Straightforward communication backed by hands-on technical depth.</li>
-<li>Launch or tune engineering processes without slowing the team.</li>
-<li>Scale teams, mentor new leads, and keep morale steady through change.</li>
-</ul>
-<h2>Additional Information</h2>
-<ul>
-<li><a href="https://qqrm.github.io/CV/">Full CV</a></li>
-<li>Download PDF: <a href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="light theme" data-dark-label="dark theme">light theme</a> · </li>
-</ul>
+<h2>Keywords for ATS</h2>
+<p>Engineering Manager, Software Engineering Manager, Rust, Microservices, SRE, SLO, MTTR, CI/CD, Kubernetes, Program Management, Supply Chain Security, Hiring, Coaching.</p>
 
 </div>
 <footer>
-<p><em><a href="ru/">Link to Russian version</a></em></p>
+<p><em><a href="ru/">View Russian version</a></em></p>
 </footer>
 <button id="theme-toggle" class="theme-toggle" aria-label="Switch to dark theme" title="Switch to dark theme">
   <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -25,6 +25,7 @@
 <header>
     <h1>Алексей Беляков</h1>
     <p>DATE</p>
+    <nav class="header-actions"><a class="action" href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF</a><a class="action" href="../">Версия EN</a><a class="action" href="https://github.com/qqrm" rel="noopener">GitHub</a><a class="action" href="https://www.linkedin.com/in/qqrm/" rel="noopener">LinkedIn</a></nav>
 </header>
 <div class='content'>
 <img class='avatar' src='../avatar.jpg' alt='Avatar'>


### PR DESCRIPTION
## Summary
- rewrite the English CV to highlight 2025-ready executive summary, impact metrics, and updated experience blocks
- add a dedicated LinkedIn About excerpt and a resume layout checklist documenting formatting rules
- expose header action buttons in the generated site, including theme-aware PDF links, and style them for both light and dark themes

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- cargo machete
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- wrkflw validate

------
https://chatgpt.com/codex/tasks/task_e_68e59e2892308332a8f28697bcc77333