### PR TITLE
Fix dark theme hover contrast for header action buttons

### DIFF
--- a/DOCS/style.css
+++ b/DOCS/style.css
@@ -43,6 +43,7 @@ header {
 html[data-theme="dark"] .header-actions .action:hover,
 html[data-theme="dark"] .header-actions .action:focus {
     color: #121212;
+    background-color: #ffffff;
 }
 
 .content h1,


### PR DESCRIPTION
## Summary
- keep header action buttons readable in dark theme by applying a white hover/focus background

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml --all
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en_dark.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru_dark.typ typst/ru/Belyakov_ru_dark.pdf
- wrkflw validate
- wrkflw run --runtime emulation --verbose .github/workflows/build-test.yml *(terminated after repeated apt-get install attempts under emulation)*

------
https://chatgpt.com/codex/tasks/task_e_68e676cabdf08332b25fb63279375834