### PR TITLE
Display avatar between name and date

### DIFF
--- a/sitegen/templates/page.hbs
+++ b/sitegen/templates/page.hbs
@@ -35,11 +35,11 @@
 </div>
 <header>
     <h1>{{name}}</h1>
+    <img class='avatar' src='{{avatar_src}}' alt='Avatar'>
     <p>{{date_str}}</p>
     {{{header_actions}}}
 </header>
 <div class='content'>
-<img class='avatar' src='{{avatar_src}}' alt='Avatar'>
 {{{html_body}}}
 </div>
 <script>

--- a/sitegen/tests/fixtures/index.html
+++ b/sitegen/tests/fixtures/index.html
@@ -35,11 +35,11 @@
 </div>
 <header>
     <h1>Alexey Belyakov</h1>
+    <img class='avatar' src='avatar.jpg' alt='Avatar'>
     <p>DATE</p>
     <nav class="header-actions"><a class="action" href="Belyakov_en_light.pdf" data-light-href="Belyakov_en_light.pdf" data-dark-href="Belyakov_en_dark.pdf" data-light-label="Download EN PDF" data-dark-label="Download EN PDF (dark)">Download EN PDF</a><a class="action" href="https://github.com/qqrm" rel="noopener">GitHub</a><a class="action" href="https://www.linkedin.com/in/qqrm/" rel="noopener">LinkedIn</a></nav>
 </header>
 <div class='content'>
-<img class='avatar' src='avatar.jpg' alt='Avatar'>
 <p>Saint Petersburg, Russia • +7 (911) 261-70-72 • qqrm@vivaldi.net • Telegram @leqqrm • Remote, full-time availability</p>
 <h2>Executive Summary</h2>
 <p>Hands-on engineering leader who scales Rust-centric platforms and keeps migrations predictable for executives and teams. Balances delivery cadence, budget guardrails, and people development while aligning product, SRE, and compliance stakeholders.</p>

--- a/sitegen/tests/fixtures/ru/index.html
+++ b/sitegen/tests/fixtures/ru/index.html
@@ -35,11 +35,11 @@
 </div>
 <header>
     <h1>Алексей Беляков</h1>
+    <img class='avatar' src='../avatar.jpg' alt='Avatar'>
     <p>DATE</p>
     <nav class="header-actions"><a class="action" href="../Belyakov_ru_light.pdf" data-light-href="../Belyakov_ru_light.pdf" data-dark-href="../Belyakov_ru_dark.pdf" data-light-label="Скачать PDF" data-dark-label="Скачать PDF (тёмная тема)">Скачать PDF</a><a class="action" href="https://github.com/qqrm" rel="noopener">GitHub</a><a class="action" href="https://www.linkedin.com/in/qqrm/" rel="noopener">LinkedIn</a></nav>
 </header>
 <div class='content'>
-<img class='avatar' src='../avatar.jpg' alt='Avatar'>
 <p>Санкт-Петербург, Россия • +7 (911) 261-70-72 • qqrm@vivaldi.net • Telegram @leqqrm • Удалённо, на полной занятости</p>
 <h2>Исполнительное резюме</h2>
 <p>Практикующий инженерный руководитель, который переводит платформы на Rust без срывов по срокам и бюджету. Поддерживаю прозрачную доставку, выстраиваю DevOps-практики и развиваю команды так, чтобы продукт, SRE и комплаенс шли в одном ритме.</p>

--- a/templates/resume.typ
+++ b/templates/resume.typ
@@ -25,13 +25,13 @@
   #let name = if name == none { default_name } else { name }
 
   #align(center)[= #name]
-  #align(center)[#datetime.today().display()]
-
   #align(center)[
     #box(width: 5cm, height: 5cm, radius: 2.5cm, clip: true, stroke: 0.75pt + palette.muted)[
       #image("../content/avatar.jpg", width: 5cm, height: 5cm)
     ]
   ]
+
+  #align(center)[#datetime.today().display()]
 
     #let find_first_section(lines, i: 0) = if i >= lines.len() {
       none


### PR DESCRIPTION
## Summary
- render the avatar in the header between the name and update date for the generated site
- update HTML fixtures to match the new header structure
- adjust the Typst resume template so the PDF shows the avatar between the name and date

## Testing
- cargo fmt --manifest-path sitegen/Cargo.toml
- cargo check --manifest-path sitegen/Cargo.toml --tests --benches
- cargo clippy --manifest-path sitegen/Cargo.toml --all-targets --all-features -- -D warnings
- cargo test --manifest-path sitegen/Cargo.toml
- (cd sitegen && cargo machete)
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_light.pdf
- typst compile --root . typst/en/Belyakov_en.typ typst/en/Belyakov_en_dark.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_light.pdf
- typst compile --root . typst/ru/Belyakov_ru.typ typst/ru/Belyakov_ru_dark.pdf

------
https://chatgpt.com/codex/tasks/task_e_68e67ed777e883328cb458fca061cb22